### PR TITLE
Playback bar: don't cover book text, add volume/speed buttons, optional progress row

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -717,6 +717,25 @@ function Audiobook:addToMainMenu(menu_items)
                         help_text = _("Experimental: when enabled, the playback control bar disappears while TTS is playing so the bottom of the page is fully visible for read-along. Pause playback (via tap-to-pause overlay or BT headset button) to bring the bar back."),
                     },
                     {
+                        text = _("Hide progress bar during read-along"),
+                        checked_func = function()
+                            return self:getSetting("hide_tts_progress_bar", false)
+                        end,
+                        callback = function()
+                            self:toggleSetting("hide_tts_progress_bar", false)
+                            -- Rebuild the bar so the change is visible right
+                            -- away rather than at the next start.
+                            local sc = self.sync_controller
+                            if sc and sc.playback_bar then
+                                sc:showPlaybackBar()
+                                if sc.playback_bar and sc.isPlaying then
+                                    sc.playback_bar:updatePlayState(sc:isPlaying())
+                                end
+                            end
+                        end,
+                        help_text = _("When enabled, the progress bar row is left out of the control bar during TTS read-along, making the bar one row shorter and leaving more of the page visible. The sentence highlight already shows how far along the page you are. The progress bar is always shown for audiobook playback, where it doubles as the seek control."),
+                    },
+                    {
                         text_func = function()
                             local styles = {
                                 background = _("Background"),

--- a/menubuilder.lua
+++ b/menubuilder.lua
@@ -439,7 +439,11 @@ function MenuBuilder.buildPitchMenu(plugin)
 end
 
 function MenuBuilder.buildVolumeMenu(plugin)
-    local volumes = {0.25, 0.50, 0.75, 1.0}
+    -- Perceptually spaced (roughly 3dB per step): linear amplitude percentage
+    -- maps badly onto loudness, so the choices cluster at the quiet end where
+    -- a given percentage change is most audible.
+    -- Keep in sync with VOLUME_STEPS in synccontroller.lua (the bar's V-/V+).
+    local volumes = {0.01, 0.02, 0.03, 0.05, 0.08, 0.12, 0.18, 0.25, 0.35, 0.50, 0.70, 1.0}
     local menu = {}
     for _i, v in ipairs(volumes) do
         table.insert(menu, {
@@ -450,6 +454,9 @@ function MenuBuilder.buildVolumeMenu(plugin)
             callback = function()
                 plugin:setSetting("speech_volume", v)
                 plugin.tts_engine:setVolume(v)
+                -- Invalidate the prefetched next sentence (synthesized at the
+                -- old volume) so the change is heard on the next sentence.
+                pcall(plugin.tts_engine._cleanPrefetch, plugin.tts_engine)
             end,
         })
     end

--- a/playbackbar.lua
+++ b/playbackbar.lua
@@ -54,6 +54,11 @@ local PlaybackBar = InputContainer:extend{
     scrubber_mode = false,
     on_seek = nil,
     current_time_str = "",
+    -- Show the progress row during TTS read-along.  Defaults to true (the
+    -- long-standing behaviour); the user can turn it off to make the bar one
+    -- row shorter, which on a rolling document is one more line of book text.
+    -- Ignored in scrubber mode, where the bar is an interactive seek control.
+    show_progress = true,
 }
 
 function PlaybackBar:init()
@@ -277,6 +282,14 @@ function PlaybackBar:setupUI()
     
     -- Main layout — generous spacing so progress bar and buttons
     -- are clearly separated from each other and the bottom edge.
+    --
+    -- The progress row is included in scrubber mode (where it is an
+    -- interactive seek control) and, during TTS read-along, only when the
+    -- user leaves show_progress on.  In read-along the sentence highlight
+    -- already shows position, so dropping the row buys back a line of book
+    -- text.  The widget itself always exists — the scrubber code and
+    -- updateProgress() reference it — it is simply not in the visible tree.
+    self._progress_shown = self.scrubber_mode or self.show_progress ~= false
     local content = VerticalGroup:new{
         align = "center",
         VerticalSpan:new{ width = Size.padding.small },
@@ -284,18 +297,20 @@ function PlaybackBar:setupUI()
             dimen = Geom:new{ w = self.width, h = self.word_display:getSize().h },
             self.word_display,
         },
-        VerticalSpan:new{ width = Size.padding.default },
-        CenterContainer:new{
+    }
+    if self._progress_shown then
+        table.insert(content, VerticalSpan:new{ width = Size.padding.default })
+        table.insert(content, CenterContainer:new{
             dimen = Geom:new{ w = self.width, h = self.progress_bar:getSize().h },
             self.progress_bar,
-        },
-        VerticalSpan:new{ width = Size.padding.large },
-        CenterContainer:new{
-            dimen = Geom:new{ w = self.width, h = button_height },
-            button_row,
-        },
-        VerticalSpan:new{ width = Size.padding.fullscreen },
-    }
+        })
+    end
+    table.insert(content, VerticalSpan:new{ width = Size.padding.large })
+    table.insert(content, CenterContainer:new{
+        dimen = Geom:new{ w = self.width, h = button_height },
+        button_row,
+    })
+    table.insert(content, VerticalSpan:new{ width = Size.padding.fullscreen })
     
     -- Frame with background
     self[1] = FrameContainer:new{
@@ -390,9 +405,14 @@ function PlaybackBar:updateProgress(progress)
     if progress ~= self.progress then
         self.progress = progress
         self.progress_bar:setPercentage(progress / 100)
-        UIManager:setDirty(self, function()
-            return "ui", self.progress_bar.dimen
-        end)
+        -- When the progress row is not in the visible tree the widget has
+        -- never been painted, so it has no dimen to refresh (and nothing to
+        -- show).  Keep the value up to date but skip the repaint.
+        if self._progress_shown then
+            UIManager:setDirty(self, function()
+                return "ui", self.progress_bar.dimen
+            end)
+        end
     end
 end
 

--- a/playbackbar.lua
+++ b/playbackbar.lua
@@ -46,6 +46,10 @@ local PlaybackBar = InputContainer:extend{
     on_forward = nil,
     on_close = nil,
     on_realign = nil,
+    on_volume_down = nil,
+    on_volume_up = nil,
+    on_speed_down = nil,
+    on_speed_up = nil,
     -- Scrubber mode for audio file playback
     scrubber_mode = false,
     on_seek = nil,
@@ -64,12 +68,26 @@ function PlaybackBar:init()
     self:setupUI()
 end
 
+-- Buttons in the row: rewind, play/pause, forward, S-, S+, V-, V+, realign, close.
+local BUTTON_COUNT = 9
+
 function PlaybackBar:setupUI()
-    local button_width = Screen:scaleBySize(60)
     local button_height = Screen:scaleBySize(40)
     local button_font_size = 20
-    local spacing = Size.padding.large
-    
+
+    -- Size the buttons to the screen instead of hardcoding a width: the row
+    -- now holds 9 buttons (S-/S+ and V-/V+ were added), which overflows a
+    -- narrow screen at the old fixed 60px.  Fit them to the space actually
+    -- available and cap at the original width on roomy screens.
+    local row_spacing = Size.padding.default
+    local row_inset = Size.padding.large * 2
+    local avail = self.width - row_inset - row_spacing * (BUTTON_COUNT - 1)
+    local button_width = math.floor(avail / BUTTON_COUNT)
+    local max_button_width = Screen:scaleBySize(60)
+    if button_width > max_button_width then button_width = max_button_width end
+    local min_button_width = Screen:scaleBySize(28)
+    if button_width < min_button_width then button_width = min_button_width end
+
     -- Rewind button (previous paragraph)
     self.rewind_button = Button:new{
         text = "⏮",
@@ -132,6 +150,60 @@ function PlaybackBar:setupUI()
         show_parent = self,
     }
 
+    -- Speed down / up buttons (step the speech rate).
+    -- Plain ASCII-ish labels on purpose: KOReader's bundled fonts have no
+    -- reliable glyphs for the tempo/speaker symbols one would reach for first.
+    self.speed_down_button = Button:new{
+        text = "S−",
+        width = button_width,
+        max_width = button_width,
+        height = button_height,
+        text_font_size = button_font_size,
+        callback = function()
+            if self.on_speed_down then self.on_speed_down() end
+        end,
+        bordersize = Size.border.button,
+        show_parent = self,
+    }
+    self.speed_up_button = Button:new{
+        text = "S+",
+        width = button_width,
+        max_width = button_width,
+        height = button_height,
+        text_font_size = button_font_size,
+        callback = function()
+            if self.on_speed_up then self.on_speed_up() end
+        end,
+        bordersize = Size.border.button,
+        show_parent = self,
+    }
+
+    -- Volume down / up buttons (step the speech volume)
+    self.vol_down_button = Button:new{
+        text = "V−",
+        width = button_width,
+        max_width = button_width,
+        height = button_height,
+        text_font_size = button_font_size,
+        callback = function()
+            if self.on_volume_down then self.on_volume_down() end
+        end,
+        bordersize = Size.border.button,
+        show_parent = self,
+    }
+    self.vol_up_button = Button:new{
+        text = "V+",
+        width = button_width,
+        max_width = button_width,
+        height = button_height,
+        text_font_size = button_font_size,
+        callback = function()
+            if self.on_volume_up then self.on_volume_up() end
+        end,
+        bordersize = Size.border.button,
+        show_parent = self,
+    }
+
     -- Close button
     self.close_button = Button:new{
         text = "✕",
@@ -154,7 +226,7 @@ function PlaybackBar:setupUI()
     self.word_display = TextWidget:new{
         text = display_text,
         face = Font:getFace("cfont", 16),
-        max_width = self.width - button_width * 5 - spacing * 7,
+        max_width = self.width - row_inset,
         truncate_left = true,
     }
     
@@ -180,17 +252,26 @@ function PlaybackBar:setupUI()
     self._scrubber_dragging = false
     self._scrubber_drag_pct = nil
     
-    -- Button row
+    -- Button row.  Gaps are Size.padding.default rather than .large: with 9
+    -- buttons the wider spacing pushed the row past the edge of a 6" screen.
     local button_row = HorizontalGroup:new{
         align = "center",
-        self.realign_button,
-        HorizontalSpan:new{ width = spacing * 2 },
         self.rewind_button,
-        HorizontalSpan:new{ width = spacing },
+        HorizontalSpan:new{ width = row_spacing },
         self.play_pause_button,
-        HorizontalSpan:new{ width = spacing },
+        HorizontalSpan:new{ width = row_spacing },
         self.forward_button,
-        HorizontalSpan:new{ width = spacing * 2 },
+        HorizontalSpan:new{ width = row_spacing },
+        self.speed_down_button,
+        HorizontalSpan:new{ width = row_spacing },
+        self.speed_up_button,
+        HorizontalSpan:new{ width = row_spacing },
+        self.vol_down_button,
+        HorizontalSpan:new{ width = row_spacing },
+        self.vol_up_button,
+        HorizontalSpan:new{ width = row_spacing },
+        self.realign_button,
+        HorizontalSpan:new{ width = row_spacing },
         self.close_button,
     }
     

--- a/synccontroller.lua
+++ b/synccontroller.lua
@@ -128,6 +128,50 @@ function SyncController:start(text)
         "mode=", Screen:getScreenMode(),
         "rotation=", Screen.getRotationMode and Screen:getRotationMode() or "?")
 
+    -- Create the bar BEFORE parsing: showing it reserves the bar's height in
+    -- the page's bottom margin, which reflows/repaginates the page (fewer
+    -- lines per page).  That repagination happens asynchronously in crengine,
+    -- so capturing the page text on the very next line reads a transitional
+    -- layout — sometimes the previous page.  Worse, the captured text then
+    -- disagrees with where the view finally settles, so advanceToNextPage
+    -- turns one page too far and skips the page on screen.  Fix: after a
+    -- FRESH reservation, defer the text capture + read-start until the reflow
+    -- settles (the same scheduleIn pattern advanceToNextPage uses).  On page
+    -- advances the bar already exists / the margin is already reserved, so
+    -- there is no reflow, no defer, and prefetched text stays valid.
+    if not self.playback_bar then
+        local was_reserved = self._bar_space_reserved
+        self:showPlaybackBar()
+        if self._bar_space_reserved and not was_reserved
+           and self.plugin and self.plugin.getCurrentPageText then
+            local controller = self
+            UIManager:scheduleIn(0.25, function()
+                if controller.state ~= controller.STATE.LOADING then
+                    logger.dbg("SyncController: start deferral aborted, state=", controller.state)
+                    return
+                end
+                local fresh = controller.plugin:getCurrentPageText()
+                if fresh and fresh ~= "" then
+                    logger.dbg("SyncController: re-fetched page text after margin reflow settle (",
+                        #text, "->", #fresh, "chars)")
+                    text = fresh
+                end
+                controller:_beginReading(text)
+            end)
+            return
+        end
+    end
+
+    self:_beginReading(text)
+end
+
+--[[--
+Parse the (settled) page text and begin sentence playback.  Split out of
+start() so the initial margin reflow can settle before we capture and read
+the page (see the deferral in start()).
+@param text string The text to read
+--]]
+function SyncController:_beginReading(text)
     -- Parse the full text into sentences and words
     self.parsed_data = self.text_parser:parse(text)
 
@@ -1211,6 +1255,62 @@ end
 --[[--
 Show the playback control bar.
 --]]
+--[[--
+Reserve the playback bar's height in the document's bottom margin so the bar
+never covers book text: the page reflows to end just above the bar.
+
+We deliberately bypass ReaderTypeset's SetPageBottomMargin event — with "sync
+top/bottom margins" enabled it would bump the TOP margin too, and it persists
+to the user's configurable settings.  Instead we compute the same scaled values
+ReaderTypeset:onSetPageMargins would and call document:setPageMargins directly:
+nothing is persisted, and restoring is just re-sending the stock SetPageMargins
+event with the user's own values.  Reflow on a slow e-ink CPU takes a moment,
+which is acceptable at TTS start/stop (and is why start() defers, see above).
+
+Rolling (CreDocument/EPUB) only — paged documents have fixed layout.
+--]]
+function SyncController:_reserveBarSpace()
+    if self._bar_space_reserved then return end
+    if not (self.plugin and self.plugin.ui and self.plugin.ui.rolling) then return end
+    local ui = self.plugin.ui
+    local tp = ui.typeset
+    if not (tp and tp.unscaled_margins and ui.document and ui.document.setPageMargins) then return end
+    if not (self.playback_bar and self.playback_bar.dimen) then return end
+    local bar_h = self.playback_bar.dimen.h
+    if not bar_h or bar_h <= 0 then return end
+    local Screen = require("device").screen
+    local m = tp.unscaled_margins
+    -- Replicate ReaderTypeset:onSetPageMargins scaling (including footer height)
+    local bottom = Screen:scaleBySize(m[4])
+    if ui.view and ui.view.footer and not ui.view.footer.reclaim_height then
+        bottom = bottom + ui.view.footer:getHeight()
+    end
+    local ok = pcall(ui.document.setPageMargins, ui.document,
+        Screen:scaleBySize(m[1]), Screen:scaleBySize(m[2]),
+        Screen:scaleBySize(m[3]), bottom + bar_h)
+    if ok then
+        self._bar_space_reserved = true
+        ui:handleEvent(Event:new("UpdatePos"))
+        logger.dbg("SyncController: reserved", bar_h, "px bottom margin for playback bar")
+    end
+end
+
+--[[--
+Give the reserved bottom-margin space back to the page.  Uses the stock
+SetPageMargins event so the user's own margins (and repaint) are restored.
+--]]
+function SyncController:_releaseBarSpace()
+    if not self._bar_space_reserved then return end
+    self._bar_space_reserved = false
+    if not (self.plugin and self.plugin.ui) then return end
+    local ui = self.plugin.ui
+    local tp = ui.typeset
+    if tp and tp.unscaled_margins then
+        ui:handleEvent(Event:new("SetPageMargins", tp.unscaled_margins))
+        logger.dbg("SyncController: restored user page margins")
+    end
+end
+
 function SyncController:showPlaybackBar()
     if self.playback_bar then
         self:hidePlaybackBar()
@@ -1243,6 +1343,9 @@ function SyncController:showPlaybackBar()
     }
 
     self.playback_bar:show()
+
+    -- Reflow the page so its text ends above the bar (nothing covered).
+    self:_reserveBarSpace()
 
     -- Force an immediate UI refresh so the bar is painted on the very next
     -- cycle, even if another (toast) notification is still visible.
@@ -1291,6 +1394,8 @@ function SyncController:hidePlaybackBar()
         self.playback_bar:hide()
         self.playback_bar = nil
     end
+    -- Give the reserved bottom-margin space back to the page.
+    self:_releaseBarSpace()
     -- Force full screen refresh on e-ink to cleanly remove bar and highlight artifacts
     UIManager:setDirty("all", "full")
 end

--- a/synccontroller.lua
+++ b/synccontroller.lua
@@ -1255,6 +1255,75 @@ end
 --[[--
 Show the playback control bar.
 --]]
+-- Perceptually spaced volume steps (roughly 3dB apart at the quiet end).
+-- Keep in sync with the volume table in MenuBuilder.buildVolumeMenu.
+local VOLUME_STEPS = {0.01, 0.02, 0.03, 0.05, 0.08, 0.12, 0.18, 0.25, 0.35, 0.50, 0.70, 1.0}
+
+-- Speech-rate steps for the bar's S-/S+ buttons.  Finer around 1.0, where
+-- small changes are most noticeable.
+local SPEED_STEPS = {0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.75, 2.0}
+
+--[[--
+Find the index of the entry in `steps` closest to `value`.
+Settings may hold a value that is not exactly on a step (set by an older
+version, or by the menu), so snap to the nearest one before stepping.
+--]]
+local function nearestStepIndex(steps, value)
+    local idx, best = 1, math.huge
+    for i, v in ipairs(steps) do
+        local d = math.abs(v - value)
+        if d < best then best, idx = d, i end
+    end
+    return idx
+end
+
+--[[--
+Step the speech volume up (+1) or down (-1) through VOLUME_STEPS.
+Persists the setting, updates the engine, and flashes the new value in the
+bar's text row for immediate feedback.
+@param direction number +1 to raise, -1 to lower
+--]]
+function SyncController:stepVolume(direction)
+    local cur = (self.plugin and self.plugin:getSetting("speech_volume", 1.0)) or 1.0
+    local idx = nearestStepIndex(VOLUME_STEPS, cur) + direction
+    idx = math.max(1, math.min(#VOLUME_STEPS, idx))
+    local vol = VOLUME_STEPS[idx]
+    if self.plugin then self.plugin:setSetting("speech_volume", vol) end
+    if self.tts_engine then
+        self.tts_engine:setVolume(vol)
+        -- Drop the already-synthesized next sentence: it was rendered at the
+        -- OLD volume (prefetch runs while the current sentence plays), so
+        -- without this the change is only heard two or more sentences later.
+        -- Costs one synth of latency, once.
+        pcall(self.tts_engine._cleanPrefetch, self.tts_engine)
+    end
+    logger.dbg("SyncController: volume ->", vol)
+    if self.playback_bar and self.playback_bar.updateCurrentWord then
+        self.playback_bar:updateCurrentWord(T(_("Volume %1%"), math.floor(vol * 100 + 0.5)))
+    end
+end
+
+--[[--
+Step the speech rate up (+1) or down (-1) through SPEED_STEPS.
+Same shape as stepVolume.
+@param direction number +1 to speed up, -1 to slow down
+--]]
+function SyncController:stepSpeed(direction)
+    local cur = (self.plugin and self.plugin:getSetting("speech_rate", 1.0)) or 1.0
+    local idx = nearestStepIndex(SPEED_STEPS, cur) + direction
+    idx = math.max(1, math.min(#SPEED_STEPS, idx))
+    local rate = SPEED_STEPS[idx]
+    if self.plugin then self.plugin:setSetting("speech_rate", rate) end
+    if self.tts_engine then
+        self.tts_engine:setRate(rate)
+        pcall(self.tts_engine._cleanPrefetch, self.tts_engine)
+    end
+    logger.dbg("SyncController: speed ->", rate)
+    if self.playback_bar and self.playback_bar.updateCurrentWord then
+        self.playback_bar:updateCurrentWord(T(_("Speed %1x"), string.format("%.2f", rate)))
+    end
+end
+
 --[[--
 Reserve the playback bar's height in the document's bottom margin so the bar
 never covers book text: the page reflows to end just above the bar.
@@ -1339,6 +1408,18 @@ function SyncController:showPlaybackBar()
         end,
         on_realign = function()
             self:realignToReadingPage()
+        end,
+        on_volume_down = function()
+            self:stepVolume(-1)
+        end,
+        on_volume_up = function()
+            self:stepVolume(1)
+        end,
+        on_speed_down = function()
+            self:stepSpeed(-1)
+        end,
+        on_speed_up = function()
+            self:stepSpeed(1)
         end,
     }
 

--- a/synccontroller.lua
+++ b/synccontroller.lua
@@ -1390,6 +1390,8 @@ function SyncController:showPlaybackBar()
 
     self.playback_bar = PlaybackBar:new{
         sync_controller = self,
+        show_progress = not (self.plugin
+            and self.plugin:getSetting("hide_tts_progress_bar", false)),
         on_play_pause = function()
             if self:isPlaying() then
                 self:pause()


### PR DESCRIPTION
## Playback bar UI fixes

Follow-up to the UI changes I mentioned in #42. This is the UI work only — it
contains nothing device-specific and nothing related to the platform-native
backend or any licensed voice.

Based on `v0.1.17.7`. Three independent commits, so you can take any subset.

---

### 1. The control bar no longer covers book text

This is the one you flagged in #42.

The bar is drawn on top of the reader at the bottom of the screen, so on
rolling (EPUB/CreDocument) documents it hid the last lines of the page —
exactly the lines being read aloud at the end of a page.

Now the bar's height is reserved in the document's bottom margin while the
bar is up, so the page reflows to end just above it, and the space is
returned when the bar closes.

Two implementation details worth a look during review:

- **Why not the `SetPageBottomMargin` event.** With "sync top/bottom margins"
  enabled that event also bumps the *top* margin, and it persists into the
  user's own configurable settings. Instead I compute the same scaled values
  `ReaderTypeset:onSetPageMargins` produces and call `document:setPageMargins`
  directly, so nothing is persisted. Releasing re-sends the stock
  `SetPageMargins` event with the user's unscaled margins, so their settings
  are never overwritten.

- **A reflow race this exposed, and its fix.** Reserving the margin
  repaginates the page, and crengine does that asynchronously. Capturing the
  page text immediately after therefore read a transitional layout (sometimes
  the *previous* page), and the captured text then disagreed with where the
  view settled — so `advanceToNextPage` turned one page too far and skipped
  the visible page. `start()` now defers the capture and read-start by 250ms
  after a *fresh* reservation and re-fetches the settled text; the parse/read
  half is split out into `_beginReading()`. Page advances reuse the existing
  reservation, so they neither reflow nor defer, and prefetched text stays
  valid.

Rolling documents only — paged formats have fixed layout. Every margin call
is `pcall`-guarded and no-ops when the typeset/document APIs are unavailable.

### 2. Volume and speed buttons on the bar

Changing volume or rate meant leaving the book for the TTS menu, which on
slow e-ink is several full refreshes for what is usually a one-step nudge.
Adds `V−`/`V+` and `S−`/`S+`.

- Volume steps are perceptually spaced (~3dB apart) rather than linear in
  amplitude — a linear percentage maps badly onto loudness, and the useful
  range on a small speaker bunches at the quiet end.
  `MenuBuilder.buildVolumeMenu` now offers the same steps so the menu and the
  buttons agree.
- Speed steps are finer around 1.0, where changes are most audible.
- Both snap to the nearest step before moving, so a value written by an older
  version (or by the old menu, e.g. `0.75`) still steps predictably.
- Both drop the prefetched next sentence via `_cleanPrefetch`. Prefetch runs
  while the current sentence plays, so that audio was rendered at the *old*
  setting; without invalidating it the change isn't heard for another two
  sentences. Costs one synth of latency, once.

**I kept the `○` re-align button.** My local build had dropped it to make
room, but removing an existing feature didn't seem like my call. To fit 9
buttons the row now sizes buttons to the available width (capped at the
previous 60px, floored so they stay tappable) and uses
`Size.padding.default` between them instead of `.large`. Checked at
600/758/1072/1264px widths. This also removes the hardcoded width that could
overflow.

### 3. Optional progress row during read-along

During read-along the progress row is redundant — the sentence highlight
already shows position — and on a rolling document it costs a line of book
text.

**Default is off, so existing behaviour is unchanged.** I deliberately did
*not* remove the row outright, since other users may rely on it. The new
"Hide progress bar during read-along" toggle sits next to the existing
"Hide control bar while playing" setting.

Scrubber mode (audiobook playback) always shows the row, since there it *is*
the seek control. The `ProgressWidget` is still constructed either way —
scrubber hit-testing and `updateProgress()` both reference it — so only its
presence in the visible tree changes. `updateProgress()` keeps the value
current but skips the repaint when the row isn't shown, since an unpainted
widget has no `dimen`. The two scrubber paths that dereference
`progress_bar.dimen` unguarded are already gated on `scrubber_mode`, where
the row is always present.

---

### Testing

Running on a PocketBook Era (FW U700.6.8.3245) as part of my daily reading.

I also wrote a small harness that loads the real `playbackbar.lua` and
`synccontroller.lua` against a stubbed KOReader widget layer and runs them on
an actual Lua interpreter, since the plugin has no test suite to hook into.
**61 checks, all passing**, covering:

- bar construction at 600/758/1072/1264px, all 9 buttons present, row fits
- progress-row presence across the scrubber/TTS × on/off matrix
- `updateProgress` is safe (no crash, value still tracked) when the row is hidden
- all four new button callbacks dispatch
- volume/speed stepping: clamping at both ends, monotonic sweeps, snapping of
  off-step legacy values, `_cleanPrefetch` invalidation ordering, and safety
  when the bar or engine is absent
- margin reserve/release: correct scaling, footer `reclaim_height` handling,
  idempotency, restore-via-stock-event, all five guard paths, and that a
  raising `setPageMargins` leaves the state unreserved
- the reflow deferral: defers on fresh reservation, uses re-fetched text,
  falls back to the original when the re-fetch is empty, aborts if state
  leaves `LOADING`, and does *not* defer on page advances or paged documents

Happy to drop, split, or rework any of the three. The margin fix is the one I'd
most want in.

### Unrelated nit

`menubuilder.lua:236` has `T(_("Volume: %1%%"), ...)`. Since `T` is
`gsub`-based rather than `string.format`, that renders as "Volume: 70%%"
with a doubled sign. Left it alone to keep this PR focused — one-character
fix if you want it.