### PR TITLE
Fix Storyteller overlay parsing: multiline SMIL and unzip brackets

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -21,7 +21,8 @@ Fixes the previous `"no timing data extracted"` failures and later highlight/nar
 - Chapter list jumps across audio files without losing the session
 - EPUB size+mtime fingerprint → wipe stale `cache/overlays/` when the book is re-exported in place
 - Fragment-id highlighting (Readest-style) preferred over fuzzy text match
-- Optional **Keep status bars during read-aloud** — mini player sits above KOReader’s bottom status bar
+- Optional **Keep status bars during read-aloud** — mini player sits above KOReader’s bottom status / progress bar
+- **Page margin reserve for mini player** (v0.1.17.23) — CRE reflows so book text ends above the mini player (same idea as TTS `_reserveBarSpace`); the overlay never covers readable text even with status + alt status + progress bars enabled
 
 ## Manual tests (Kindle + Bose QuietComfort Ultra Gen1 / AirPods Pro 3)
 
@@ -39,6 +40,7 @@ All verified working:
 - [x] **Resume after close** — reopen book, resume near last position
 - [x] **Re-export / cache** — regenerating the Storyteller EPUB invalidates stale overlay audio cache; highlights match new alignment
 - [x] **Bluetooth audio** — Bose QuietComfort Ultra (Gen1) and AirPods Pro 3; sync/highlights track audible narration
+- [x] **Keep status bars** — with bottom status + progress (+ alt status bar), mini player sits in reserved chrome; book text reflows above it (v0.1.17.23)
 
 ## Automated / fixture checks
 

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,8 +1,8 @@
 ## Summary
 
-Full Storyteller EPUB3 Media Overlay read-aloud support for KOReader (validated on Kindle + Bose QuietComfort Ultra Gen1).
+Full Storyteller EPUB3 Media Overlay read-aloud support for KOReader (validated on Kindle + Bose QuietComfort Ultra Gen1, later AirPods Pro 3).
 
-Fixes the previous `"no timing data extracted"` failures and later highlight/narration desync after Storyteller re-exports.
+Fixes the previous `"no timing data extracted"` failures and later highlight/narration desync after Storyteller re-exports. Follow-up field tests (Aug 2026) also fixed **manual page-turn seeking audio** (must not restart/jump tracks) and status-bar UX.
 
 ### Core parsing
 - Multiline SMIL/OPF (`RE_ANY_LAZY`) — Lua `.` does not match newlines
@@ -14,25 +14,31 @@ Fixes the previous `"no timing data extracted"` failures and later highlight/nar
 - Live SMIL load progress on e-ink (`forceRePaint`)
 - **Play aligned from here** via fragment id + scored text match (no crawl)
 - Page-follow without `GotoViewRel` freeze
-- Stale highlight cleared when browsing away while paused/playing
-- **Return to read-aloud** cue on the mini player bar (tappable / ◎)
+- **Manual page turns never seek/restart audio** — highlighting pauses, **Return to read-aloud** cue on the mini bar; auto-follow resumes on return or when narration catches up
+- Soft track transitions for multi-file Storyteller audio (playlist parts are Storyteller chunks, not Kindle-invented)
+- Player title = book title (not first SMIL sentence text)
+- ⏭/⏮ in overlay mode = SMIL content-document chapters (not raw ~4 min audio parts)
+- Chapter list jumps across audio files without losing the session
 - EPUB size+mtime fingerprint → wipe stale `cache/overlays/` when the book is re-exported in place
 - Fragment-id highlighting (Readest-style) preferred over fuzzy text match
+- Optional **Keep status bars during read-aloud** — mini player sits above KOReader’s bottom status bar
 
-## Manual tests (Kindle + Bose QuietComfort Ultra Gen1)
+## Manual tests (Kindle + Bose QuietComfort Ultra Gen1 / AirPods Pro 3)
 
 All verified working:
 
 - [x] **Cold start** — KOReader restart, open *Le Roi de fer*, Play aligned/enriched audiobook; SMIL loads with live progress (no `"no timing data"`)
 - [x] **Highlight sync** — first sentences highlight correctly; page auto-follow stays on the spoken sentence
 - [x] **Play aligned from here** — long-press mid-chapter; audio starts at that sentence
-- [x] **Return to read-aloud** — browse away while playing/paused; mini bar shows *Return to read-aloud*; tap / ◎ restores position + highlight
+- [x] **Return to read-aloud** — browse away while playing/paused; mini bar shows *Return to read-aloud*; tap / ◎ restores position + highlight; **audio keeps playing** (no seek/restart)
+- [x] **Manual page turn mid-chapter** — peek ahead: no audio jump to earlier track; highlight off + return cue
 - [x] **Pause + browse** — pause, change page: no stale highlight; return cue works
 - [x] **Seek / skip** — sentence/chapter controls stay aligned with text
 - [x] **Chapter list** — jump lands on correct text + audio
+- [x] **Natural multi-file advance** — Storyteller ~4 min audio parts chain (A2DP bridge covered in companion AirPods PR when needed)
 - [x] **Resume after close** — reopen book, resume near last position
 - [x] **Re-export / cache** — regenerating the Storyteller EPUB invalidates stale overlay audio cache; highlights match new alignment
-- [x] **Bluetooth audio** — Bose QuietComfort Ultra (Gen1) headset; sync/highlights track audible narration
+- [x] **Bluetooth audio** — Bose QuietComfort Ultra (Gen1) and AirPods Pro 3; sync/highlights track audible narration
 
 ## Automated / fixture checks
 
@@ -44,4 +50,5 @@ All verified working:
 
 - Deploy: `koreader/plugins/audiobook.koplugin/` — full KOReader restart after update
 - First play after EPUB change re-extracts embedded audio (~hundreds of MB); expected
-- Related: #32; Readest reference: [readest/readest#5562](https://github.com/readest/readest/pull/5562)
+- Storyteller embeds many short audio files inside the EPUB; the plugin plays them as a playlist (Readest presents one continuous timeline)
+- Related: #32; companion AirPods A2DP PR for Kindle PW11 idle-route drops; Readest reference: [readest/readest#5562](https://github.com/readest/readest/pull/5562)

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,51 @@
+## Summary
+
+Fixes EPUB3 Media Overlay parsing for **Storyteller read-aloud EPUBs** on KOReader (Kindle/Kobo/etc.).
+
+Storyteller books failed with:
+
+`No Media Overlays found: no timing data extracted`
+
+Two independent bugs caused this:
+
+### 1. Multiline SMIL/OPF (Lua regex)
+
+Storyteller pretty-prints SMIL/OPF. The parser used `(.-)`, but in Lua/LuaJIT `.` **does not match newlines**, so zero `<par>` blocks matched.
+
+### 2. `unzip` wildcard characters in Storyteller filenames (Kindle blocker)
+
+Storyteller encodes series tags in filenames, e.g.:
+
+`MediaOverlays/Druon,Maurice-[Rois Maudits-1]Le Roi de fer(1955)...split_003.smil`
+
+Info-ZIP `unzip` treats `[]` as **wildcards** in member names. `unzip -l` still lists `.smil` files (so overlay detection passes), but `unzip -p` with the raw path returns **empty content** for every bracketed SMIL/HTML file → zero timing entries.
+
+Fix: escape literal `[` as `[[]` and `]` as `[]]` before calling `unzip -p` / `unzip -o`.
+
+This is a follow-up to overlay work from #32 / DroidThug's PW5 merge (manifest href fixes, LuaJIT compile fixes). Those did not cover multiline XML or bracketed Storyteller paths.
+
+Readest/foliate readers use ZIP + DOM parsing and are unaffected ([readest/readest#5562](https://github.com/readest/readest/pull/5562)).
+
+## Changes
+
+- `RE_ANY_LAZY = "([%z\1-\255]-)"` for cross-line XML captures
+- `_escapeUnzipMember()` for Info-ZIP literal bracket escaping
+- `_compactXml()` collapses `>\s+<` before parsing (extra safety)
+- `dev/test_epubmediaoverlay_multiline.lua` smoke test
+
+## Test plan
+
+- [ ] `luajit dev/test_epubmediaoverlay_multiline.lua` → `ok`
+- [ ] Storyteller EPUB with bracketed filenames (*Le Roi de fer*, 27 SMIL / 4648 `<par>` entries)
+- [ ] Storyteller EPUB without brackets (`1984 - Readaloud.epub`, 25 SMIL / 6967 entries)
+- [ ] **Tools → Audiobook Read-Along → Play aligned/enriched audiobook** on Kindle PW5 + KOReader
+- [ ] Sentence highlight sync regression on a book that already worked
+
+## Verification
+
+| Book | Issue | Before | After |
+|------|-------|--------|-------|
+| Le Roi de fer | multiline SMIL + `[Series-1]` paths | 0 timing | 4648 timing |
+| 1984 Readaloud | multiline SMIL only | 0 timing | 6967 timing |
+
+Related: #32

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -20,7 +20,7 @@ Storyteller encodes series tags in filenames, e.g.:
 
 Info-ZIP `unzip` treats `[]` as **wildcards** in member names. `unzip -l` still lists `.smil` files (so overlay detection passes), but `unzip -p` with the raw path returns **empty content** for every bracketed SMIL/HTML file → zero timing entries.
 
-Fix: escape literal `[` as `[[]` and `]` as `[]]` before calling `unzip -p` / `unzip -o`.
+Fix: escape literal `[` as `[[]` before calling `unzip -p` / `unzip -o` (Info-ZIP convention).
 
 This is a follow-up to overlay work from #32 / DroidThug's PW5 merge (manifest href fixes, LuaJIT compile fixes). Those did not cover multiline XML or bracketed Storyteller paths.
 

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,51 +1,47 @@
 ## Summary
 
-Fixes EPUB3 Media Overlay parsing for **Storyteller read-aloud EPUBs** on KOReader (Kindle/Kobo/etc.).
+Full Storyteller EPUB3 Media Overlay read-aloud support for KOReader (validated on Kindle + Bose QuietComfort Ultra Gen1).
 
-Storyteller books failed with:
+Fixes the previous `"no timing data extracted"` failures and later highlight/narration desync after Storyteller re-exports.
 
-`No Media Overlays found: no timing data extracted`
+### Core parsing
+- Multiline SMIL/OPF (`RE_ANY_LAZY`) — Lua `.` does not match newlines
+- Info-ZIP bracket escape (`[` → `[[]`) for Storyteller paths like `Author-[Series-1]Title...smil`
+- `_compactXml()` safety for pretty-printed XML
+- Spine-ordered SMIL parse; nested `<span>` text extraction
 
-Two independent bugs caused this:
+### Playback / UX
+- Live SMIL load progress on e-ink (`forceRePaint`)
+- **Play aligned from here** via fragment id + scored text match (no crawl)
+- Page-follow without `GotoViewRel` freeze
+- Stale highlight cleared when browsing away while paused/playing
+- **Return to read-aloud** cue on the mini player bar (tappable / ◎)
+- EPUB size+mtime fingerprint → wipe stale `cache/overlays/` when the book is re-exported in place
+- Fragment-id highlighting (Readest-style) preferred over fuzzy text match
 
-### 1. Multiline SMIL/OPF (Lua regex)
+## Manual tests (Kindle + Bose QuietComfort Ultra Gen1)
 
-Storyteller pretty-prints SMIL/OPF. The parser used `(.-)`, but in Lua/LuaJIT `.` **does not match newlines**, so zero `<par>` blocks matched.
+All verified working:
 
-### 2. `unzip` wildcard characters in Storyteller filenames (Kindle blocker)
+- [x] **Cold start** — KOReader restart, open *Le Roi de fer*, Play aligned/enriched audiobook; SMIL loads with live progress (no `"no timing data"`)
+- [x] **Highlight sync** — first sentences highlight correctly; page auto-follow stays on the spoken sentence
+- [x] **Play aligned from here** — long-press mid-chapter; audio starts at that sentence
+- [x] **Return to read-aloud** — browse away while playing/paused; mini bar shows *Return to read-aloud*; tap / ◎ restores position + highlight
+- [x] **Pause + browse** — pause, change page: no stale highlight; return cue works
+- [x] **Seek / skip** — sentence/chapter controls stay aligned with text
+- [x] **Chapter list** — jump lands on correct text + audio
+- [x] **Resume after close** — reopen book, resume near last position
+- [x] **Re-export / cache** — regenerating the Storyteller EPUB invalidates stale overlay audio cache; highlights match new alignment
+- [x] **Bluetooth audio** — Bose QuietComfort Ultra (Gen1) headset; sync/highlights track audible narration
 
-Storyteller encodes series tags in filenames, e.g.:
+## Automated / fixture checks
 
-`MediaOverlays/Druon,Maurice-[Rois Maudits-1]Le Roi de fer(1955)...split_003.smil`
+- [x] `luajit dev/test_epubmediaoverlay_multiline.lua` smoke test
+- [x] Storyteller EPUB with bracketed filenames (*Le Roi de fer*)
+- [x] Timing extraction non-zero after parse
 
-Info-ZIP `unzip` treats `[]` as **wildcards** in member names. `unzip -l` still lists `.smil` files (so overlay detection passes), but `unzip -p` with the raw path returns **empty content** for every bracketed SMIL/HTML file → zero timing entries.
+## Notes
 
-Fix: escape literal `[` as `[[]` before calling `unzip -p` / `unzip -o` (Info-ZIP convention).
-
-This is a follow-up to overlay work from #32 / DroidThug's PW5 merge (manifest href fixes, LuaJIT compile fixes). Those did not cover multiline XML or bracketed Storyteller paths.
-
-Readest/foliate readers use ZIP + DOM parsing and are unaffected ([readest/readest#5562](https://github.com/readest/readest/pull/5562)).
-
-## Changes
-
-- `RE_ANY_LAZY = "([%z\1-\255]-)"` for cross-line XML captures
-- `_escapeUnzipMember()` for Info-ZIP literal bracket escaping
-- `_compactXml()` collapses `>\s+<` before parsing (extra safety)
-- `dev/test_epubmediaoverlay_multiline.lua` smoke test
-
-## Test plan
-
-- [ ] `luajit dev/test_epubmediaoverlay_multiline.lua` → `ok`
-- [ ] Storyteller EPUB with bracketed filenames (*Le Roi de fer*, 27 SMIL / 4648 `<par>` entries)
-- [ ] Storyteller EPUB without brackets (`1984 - Readaloud.epub`, 25 SMIL / 6967 entries)
-- [ ] **Tools → Audiobook Read-Along → Play aligned/enriched audiobook** on Kindle PW5 + KOReader
-- [ ] Sentence highlight sync regression on a book that already worked
-
-## Verification
-
-| Book | Issue | Before | After |
-|------|-------|--------|-------|
-| Le Roi de fer | multiline SMIL + `[Series-1]` paths | 0 timing | 4648 timing |
-| 1984 Readaloud | multiline SMIL only | 0 timing | 6967 timing |
-
-Related: #32
+- Deploy: `koreader/plugins/audiobook.koplugin/` — full KOReader restart after update
+- First play after EPUB change re-extracts embedded audio (~hundreds of MB); expected
+- Related: #32; Readest reference: [readest/readest#5562](https://github.com/readest/readest/pull/5562)

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.14",
+    version = "0.1.17.22",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.23",
+    version = "0.1.17.24",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.22",
+    version = "0.1.17.23",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -738,20 +738,23 @@ function AudiobookPlayer:setupUI()
     end
 end
 
---- Bottom inset so the mini player can sit above KOReader's status bar.
+--- Bottom inset so the mini player can sit above KOReader's status/progress bar.
+--- MediaSync also reflows page margins by this chrome height + mini bar so
+--- book text never renders underneath the player.
 function AudiobookPlayer:_statusBarInset()
     if not self.keep_reader_status_bars then return 0 end
     local ui = self.plugin and self.plugin.ui
     local view = ui and ui.view
-    if not view then return 0 end
-    local inset = 0
-    if view.footer_visible and view.footer then
-        local ok, h = pcall(function() return view.footer:getHeight() end)
-        if ok and type(h) == "number" and h > 0 then
-            inset = inset + h
-        end
-    end
-    return inset
+    if not view or not view.footer_visible or not view.footer then return 0 end
+    local ok, h = pcall(function() return view.footer:getHeight() end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    ok, h = pcall(function()
+        local d = view.footer.dimen
+        return d and d.h or 0
+    end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    -- Last resort: typical status+progress stack on PW11-class screens.
+    return Screen:scaleBySize(36)
 end
 
 function AudiobookPlayer:_miniBarY()

--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -142,6 +142,7 @@ function AudiobookPlayer:init()
     self.height = Screen:getHeight()
     self.dimen = Geom:new{ w = self.width, h = self.height }
     self._minimized = false
+    self._return_hint_active = false
     self._rotation_mode = Screen:getRotationMode()
     self:setupUI()
 end
@@ -1299,15 +1300,48 @@ function AudiobookPlayer:_updateScrubberPreview(x)
 end
 
 function AudiobookPlayer:_updateMiniWidgets()
-    -- Show track filename (output_name) in mini bar; fall back to title
-    local track = self.output_name
-    if not track or track == "" then
-        track = self.title or _("Audiobook")
+    -- Show track filename (output_name) in mini bar; fall back to title.
+    -- When browsing away from the audio page, the title becomes a clear
+    -- "Return to read-aloud" cue (tapping the bar centers on the sentence).
+    local track
+    if self._return_hint_active then
+        track = _("Return to read-aloud")
+    else
+        track = self.output_name
+        if not track or track == "" then
+            track = self.title or _("Audiobook")
+        end
     end
-    self._mini_title:setText(track)
-    self._mini_time:setText(self.current_time_str or "")
-    local txt = self.is_playing and "⏸" or "▶"
-    self._mini_play_pause:setText(txt, self._mini_play_pause.width)
+    if self._mini_title then
+        self._mini_title:setText(track)
+    end
+    if self._mini_time then
+        self._mini_time:setText(self.current_time_str or "")
+    end
+    if self._mini_play_pause then
+        local txt = self.is_playing and "⏸" or "▶"
+        self._mini_play_pause:setText(txt, self._mini_play_pause.width)
+    end
+    if self._mini_refocus then
+        -- Make the existing ○ control more obvious while the hint is active.
+        local label = self._return_hint_active and "◎" or "○"
+        self._mini_refocus:setText(label, self._mini_refocus.width)
+    end
+end
+
+--- Toggle Readest-style "return to read-aloud" cue on the mini bar.
+-- When active, tapping the mini bar (outside transport buttons) refocuses
+-- instead of expanding the full player.
+function AudiobookPlayer:setReturnHint(active)
+    active = not not active
+    if self._return_hint_active == active then return end
+    self._return_hint_active = active
+    if self._minimized then
+        self:_updateMiniWidgets()
+        UIManager:setDirty(self, function()
+            return "ui", self.dimen
+        end)
+    end
 end
 
 -- Show / hide
@@ -1437,6 +1471,14 @@ function AudiobookPlayer:handleEvent(event)
                         else
                             logger.warn("ABP: refocus button has no callback")
                         end
+                        return true
+                    end
+                    -- While browsing away from the narration page, a tap on
+                    -- the unused mini-bar area means "return to read-aloud"
+                    -- (same as ○), not "expand full player".
+                    if self._return_hint_active and self.on_refocus then
+                        logger.warn("ABP: return-hint bar tap -> refocus")
+                        self:onRefocus()
                         return true
                     end
                     -- Tap anywhere else on the mini bar -> restore full player

--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -678,7 +678,8 @@ function AudiobookPlayer:setupUI()
     -- Create the centered title/time stack now that side buttons have reserved
     -- their full width, so the text cannot overlap the volume/sync buttons.
     self._mini_title = TextWidget:new{
-        text = self.output_name or self.title or _("Audiobook"),
+        text = (self.chapter_title and self.chapter_title ~= "" and self.chapter_title)
+            or self.output_name or self.title or _("Audiobook"),
         face = Font:getFace("cfont", 13),
         max_width = center_max_width,
         truncate_left = false,
@@ -904,9 +905,18 @@ end
 function AudiobookPlayer:updateChapterTitle(title)
     if title and title ~= self.chapter_title then
         self.chapter_title = title
-        self.chapter_widget:setText(title)
+        if self.chapter_widget then
+            self.chapter_widget:setText(title)
+        end
+        -- Mini bar prefers chapter_title for read-aloud (see _updateMiniWidgets).
+        if self._mini_title then
+            self:_updateMiniWidgets()
+        end
         UIManager:setDirty(self, function()
-            return "ui", self.chapter_widget.dimen
+            if self._minimized then
+                return "ui", self.dimen
+            end
+            return "ui", self.chapter_widget and self.chapter_widget.dimen or self.dimen
         end)
     end
 end
@@ -1097,9 +1107,16 @@ function AudiobookPlayer:updateOutputName(name)
     if name and name ~= self.output_name then
         self.output_name = name
         self.output_widget = self:_buildOutputWidget(name)
-        UIManager:setDirty(self, function()
-            return "ui", self.output_widget.dimen
-        end)
+        if self._minimized then
+            self:_updateMiniWidgets()
+            UIManager:setDirty(self, function()
+                return "ui", self.dimen
+            end)
+        else
+            UIManager:setDirty(self, function()
+                return "ui", self.output_widget and self.output_widget.dimen or self.dimen
+            end)
+        end
     end
 end
 
@@ -1358,14 +1375,18 @@ function AudiobookPlayer:_updateScrubberPreview(x)
 end
 
 function AudiobookPlayer:_updateMiniWidgets()
-    -- Show track filename (output_name) in mini bar; fall back to title.
+    -- Read-aloud: show the live SMIL chapter title. Fall back to output_name
+    -- (track/book) when no chapter is known yet.
     -- When browsing away from the audio page, the title becomes a clear
     -- "Return to read-aloud" cue (tapping the bar centers on the sentence).
     local track
     if self._return_hint_active then
         track = _("Return to read-aloud")
     else
-        track = self.output_name
+        track = self.chapter_title
+        if not track or track == "" then
+            track = self.output_name
+        end
         if not track or track == "" then
             track = self.title or _("Audiobook")
         end

--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -60,6 +60,10 @@ local AudiobookPlayer = InputContainer:extend{
     on_play_pause = nil,
     on_skip_back = nil,
     on_skip_forward = nil,
+    on_fix_audio = nil,
+    show_fix_audio = false,
+    -- When true, mini bar sits above KOReader's bottom status bar.
+    keep_reader_status_bars = false,
     on_prev_chapter = nil,
     on_next_chapter = nil,
     on_seek = nil,
@@ -142,6 +146,10 @@ function AudiobookPlayer:init()
     self.height = Screen:getHeight()
     self.dimen = Geom:new{ w = self.width, h = self.height }
     self._minimized = false
+    -- Do not claim the whole screen / footer while the mini player is up —
+    -- otherwise ReaderFooter may skip updates ("lost" status bar).
+    self.covers_fullscreen = false
+    self.covers_footer = not self.keep_reader_status_bars
     self._return_hint_active = false
     self._rotation_mode = Screen:getRotationMode()
     self:setupUI()
@@ -224,10 +232,22 @@ function AudiobookPlayer:setupUI()
         show_parent = self,
     }
 
+    -- Kindle AirPods: reconnect A2DP when the stream goes silent mid-play.
+    self.fix_audio_button = Button:new{
+        text = _("BT"),
+        width = button_size,
+        height = button_size,
+        text_font_size = 14,
+        callback = function() self:onFixAudio() end,
+        bordersize = 0,
+        show_parent = self,
+    }
+
     -- Count visible buttons for title width calculation
     local visible_buttons = 5 -- chapter_list, sleep_timer, speed, minimize, close
     if self.show_shuffle then visible_buttons = visible_buttons + 1 end
     if self.show_loop then visible_buttons = visible_buttons + 1 end
+    if self.show_fix_audio then visible_buttons = visible_buttons + 1 end
     self.title_widget = TextWidget:new{
         text = self.title or _("Audiobook"),
         face = Font:getFace("cfont", 18),
@@ -249,6 +269,10 @@ function AudiobookPlayer:setupUI()
     end
     if self.show_loop then
         table.insert(top_row_items, self.loop_button)
+        table.insert(top_row_items, HorizontalSpan:new{ width = math.floor(spacing / 2) })
+    end
+    if self.show_fix_audio then
+        table.insert(top_row_items, self.fix_audio_button)
         table.insert(top_row_items, HorizontalSpan:new{ width = math.floor(spacing / 2) })
     end
     table.insert(top_row_items, CenterContainer:new{
@@ -709,11 +733,37 @@ function AudiobookPlayer:setupUI()
     -- follow are the UI) with only the mini bar for transport control,
     -- instead of covering the text with the full-screen player.
     if self.start_minimized then
-        self._minimized = true
-        self.dimen.h = self._mini_height
-        self.dimen.y = self.height - self._mini_height
+        self:_applyMinimizedGeometry()
         self:_updateMiniWidgets()
     end
+end
+
+--- Bottom inset so the mini player can sit above KOReader's status bar.
+function AudiobookPlayer:_statusBarInset()
+    if not self.keep_reader_status_bars then return 0 end
+    local ui = self.plugin and self.plugin.ui
+    local view = ui and ui.view
+    if not view then return 0 end
+    local inset = 0
+    if view.footer_visible and view.footer then
+        local ok, h = pcall(function() return view.footer:getHeight() end)
+        if ok and type(h) == "number" and h > 0 then
+            inset = inset + h
+        end
+    end
+    return inset
+end
+
+function AudiobookPlayer:_miniBarY()
+    return self.height - self._mini_height - self:_statusBarInset()
+end
+
+function AudiobookPlayer:_applyMinimizedGeometry()
+    self._minimized = true
+    self.covers_fullscreen = false
+    self.covers_footer = not self.keep_reader_status_bars
+    self.dimen.h = self._mini_height
+    self.dimen.y = self:_miniBarY()
 end
 
 -- Callback handlers
@@ -742,14 +792,12 @@ function AudiobookPlayer:onClose()
 end
 
 function AudiobookPlayer:onMinimize()
-    self._minimized = true
     self._scrubber_dragging = false
     self._scrubber_drag_pct = nil
     self:_updateMiniWidgets()
     -- Shrink dimen to only cover the mini bar area at the bottom
     -- so touch events pass through to the rest of the screen.
-    self.dimen.h = self._mini_height
-    self.dimen.y = self.height - self._mini_height
+    self:_applyMinimizedGeometry()
     logger.warn("AudiobookPlayer: minimized, dimen=",
         self.dimen.x, self.dimen.y, self.dimen.w, self.dimen.h)
     -- Full refresh to erase the full-screen player image and redraw only the
@@ -762,6 +810,9 @@ function AudiobookPlayer:_restore()
     self._minimized = false
     self._scrubber_dragging = false
     self._scrubber_drag_pct = nil
+    -- Full-screen player covers the book (and status bars) while expanded.
+    self.covers_fullscreen = true
+    self.covers_footer = true
     -- Restore dimen to full screen so we receive all events again
     self.dimen.h = self.height
     self.dimen.y = 0
@@ -778,6 +829,10 @@ end
 
 function AudiobookPlayer:onLoop()
     if self.on_loop then self.on_loop() end
+end
+
+function AudiobookPlayer:onFixAudio()
+    if self.on_fix_audio then self.on_fix_audio() end
 end
 
 function AudiobookPlayer:onSeek(pct)
@@ -1414,8 +1469,9 @@ function AudiobookPlayer:handleEvent(event)
                 self.plugin.session_recorder:recordGesture(ges, "audiobookplayer")
             end
             if ges and ges.pos then
-                local mini_y = self.height - self._mini_height
+                local mini_y = self:_miniBarY()
                 local on_bar = ges.pos.y >= mini_y
+                    and ges.pos.y < mini_y + self._mini_height
                 if on_bar and ges.ges == "tap" then
                     -- Tap on play/pause button?
                     if self:_isTapOnWidget(ges.pos, self._mini_play_pause) then
@@ -1682,11 +1738,12 @@ function AudiobookPlayer:_doRebuild(new_w, new_h)
     self:_updateMiniWidgets()
     -- Position at the correct coordinates for the new dimensions
     self.visible = true
-    self._minimized = was_minimized
     if was_minimized then
-        self.dimen.h = self._mini_height
-        self.dimen.y = self.height - self._mini_height
+        self:_applyMinimizedGeometry()
     else
+        self._minimized = false
+        self.covers_fullscreen = true
+        self.covers_footer = true
         self.dimen.h = self.height
         self.dimen.y = 0
     end
@@ -1736,11 +1793,11 @@ end
 function AudiobookPlayer:paintTo(bb, x, y)
     if not self.visible then return end
     if self._minimized then
-        -- Draw only the mini player bar at bottom.
+        -- Draw only the mini player bar at bottom (optionally above status bar).
         -- UIManager's window.y for this widget is always 0 (set when first shown),
         -- so we must add the bottom offset ourselves.
         if self._mini_bar and self._mini_bar.paintTo then
-            self._mini_bar:paintTo(bb, x or 0, (y or 0) + self.height - self._mini_height)
+            self._mini_bar:paintTo(bb, x or 0, (y or 0) + self:_miniBarY())
         end
         return
     end

--- a/dev/test_epubmediaoverlay_multiline.lua
+++ b/dev/test_epubmediaoverlay_multiline.lua
@@ -1,8 +1,7 @@
 #!/usr/bin/env luajit
 --[[--
-Smoke test: multiline Storyteller SMIL/OPF must parse under Lua patterns.
+Smoke test for Storyteller EPUB overlay parsing helpers.
 
-Run from repo root:
   luajit dev/test_epubmediaoverlay_multiline.lua
 
 No KOReader install required.
@@ -10,87 +9,52 @@ No KOReader install required.
 
 local RE_ANY_LAZY = "([%z\1-\255]-)"
 
-local function count(pattern, text)
+local function escape_unzip_member(path)
+    path = path:gsub("%[", "[[]")
+    path = path:gsub("%]", "[]]")
+    return path
+end
+
+local function compact_xml(xml)
+    return xml:gsub(">%s+<", "><")
+end
+
+local function count_par(smil, pattern)
     local n = 0
-    for _ in text:gmatch(pattern) do
+    for _ in smil:gmatch(pattern) do
         n = n + 1
     end
     return n
 end
 
 local multiline_smil = [[
-<smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+<smil>
   <body>
-    <seq epub:textref="chapter.xhtml">
-      <par id="s0">
-        <text src="../chapter.xhtml#s0"/>
-        <audio src="../Audio/00001.mp4" clipBegin="0.000s" clipEnd="12.340s"/>
-      </par>
-      <par id="s1">
-        <text src="../chapter.xhtml#s1"/>
-        <audio src="../Audio/00001.mp4" clipBegin="12.340s" clipEnd="25.180s"/>
-      </par>
-    </seq>
+    <par id="s0">
+      <text src="../Author-[Series-1]Title.html#s0"/>
+      <audio src="../Audio/00001.mp4" clipBegin="0.000s" clipEnd="12.340s"/>
+    </par>
   </body>
 </smil>
 ]]
 
-local multiline_opf = [[
-<package>
-  <manifest>
-    <item id="ch1" href="text/ch1.xhtml" media-type="application/xhtml+xml" media-overlay="mo1"/>
-    <item id="mo1" href="MediaOverlays/ch1.smil" media-type="application/smil+xml"/>
-  </manifest>
-  <spine>
-    <itemref idref="ch1"/>
-  </spine>
-</package>
-]]
+local storyteller_member =
+    "MediaOverlays/Author-[Series-1]Title_split_003.smil"
+local escaped = escape_unzip_member(storyteller_member)
 
-local multiline_html = [[
-<p>
-  <span id="s0">Première phrase.</span>
-  <span id="s1">Deuxième phrase.</span>
-</p>
-]]
-
-local broken_par = count("<par([^>]*)>(.-)</par>", multiline_smil)
-local fixed_par = count("<par([^>]*)>" .. RE_ANY_LAZY .. "</par>", multiline_smil)
-
-local broken_manifest = multiline_opf:match("<manifest[^>]*>(.-)</manifest>") or ""
-local fixed_manifest = multiline_opf:match("<manifest[^>]*>" .. RE_ANY_LAZY .. "</manifest>") or ""
-
-local broken_spine = multiline_opf:match("<spine[^>]*>(.-)</spine>") or ""
-local fixed_spine = multiline_opf:match("<spine[^>]*>" .. RE_ANY_LAZY .. "</spine>") or ""
-
-local broken_span = count('<span[^>]-id="([^"]+)"[^>]*>(.-)</span>', multiline_html)
-local fixed_span = count('<span[^>]-id="([^"]+)"[^>]*>' .. RE_ANY_LAZY .. '</span>', multiline_html)
+local broken = count_par(multiline_smil, "<par([^>]*)>(.-)</par>")
+local fixed = count_par(compact_xml(multiline_smil), "<par([^>]*)>" .. RE_ANY_LAZY .. "</par>")
 
 local failures = {}
 
-if broken_par ~= 0 then
-    table.insert(failures, "expected broken par pattern to miss multiline SMIL, got " .. broken_par)
+if broken ~= 0 then
+    table.insert(failures, "broken par pattern should miss multiline SMIL")
 end
-if fixed_par ~= 2 then
-    table.insert(failures, "expected 2 par blocks, got " .. fixed_par)
+if fixed ~= 1 then
+    table.insert(failures, "expected 1 par after compact+fixed, got " .. fixed)
 end
-if broken_manifest ~= "" then
-    table.insert(failures, "expected broken manifest pattern to miss multiline OPF")
-end
-if fixed_manifest == "" or not fixed_manifest:find("media-overlay") then
-    table.insert(failures, "expected fixed manifest pattern to capture overlay items")
-end
-if broken_spine ~= "" then
-    table.insert(failures, "expected broken spine pattern to miss multiline OPF")
-end
-if fixed_spine == "" or not fixed_spine:find("itemref") then
-    table.insert(failures, "expected fixed spine pattern to capture itemref")
-end
-if broken_span ~= 0 then
-    table.insert(failures, "expected broken span pattern to miss (if spans were multiline)")
-end
-if fixed_span ~= 2 then
-    table.insert(failures, "expected 2 sentence spans, got " .. fixed_span)
+if escaped ~= "MediaOverlays/Author-[[]Series-1]Title_split_003.smil" then
+    table.insert(failures, "unexpected unzip escape: " .. escaped)
 end
 
 if #failures > 0 then
@@ -101,4 +65,4 @@ if #failures > 0 then
     os.exit(1)
 end
 
-print("ok: multiline Storyteller SMIL/OPF patterns parse correctly")
+print("ok: multiline SMIL patterns and unzip member escaping")

--- a/dev/test_epubmediaoverlay_multiline.lua
+++ b/dev/test_epubmediaoverlay_multiline.lua
@@ -10,9 +10,7 @@ No KOReader install required.
 local RE_ANY_LAZY = "([%z\1-\255]-)"
 
 local function escape_unzip_member(path)
-    path = path:gsub("%[", "[[]")
-    path = path:gsub("%]", "[]]")
-    return path
+    return path:gsub("%[", "[[]")
 end
 
 local function compact_xml(xml)

--- a/dev/test_epubmediaoverlay_multiline.lua
+++ b/dev/test_epubmediaoverlay_multiline.lua
@@ -2,9 +2,12 @@
 --[[--
 Smoke test for Storyteller EPUB overlay parsing helpers.
 
-  luajit dev/test_epubmediaoverlay_multiline.lua
+Uses real fixtures extracted from a Storyteller read-aloud EPUB.
+Run from repo root:
+  luajit dev/test_epubmediaoverlay_multiline.lua [fixtures_dir]
 
-No KOReader install required.
+Default fixtures_dir: ../scripts/_fixtures (when run from audiobook.koplugin clone
+next to THE-BEAST scripts) or pass absolute path to scripts/_fixtures.
 --]]
 
 local RE_ANY_LAZY = "([%z\1-\255]-)"
@@ -17,42 +20,83 @@ local function compact_xml(xml)
     return xml:gsub(">%s+<", "><")
 end
 
+local function read_file(path)
+    local f, err = io.open(path, "rb")
+    if not f then return nil, err end
+    local data = f:read("*a")
+    f:close()
+    return data
+end
+
 local function count_par(smil, pattern)
     local n = 0
-    for _ in smil:gmatch(pattern) do
+    for _a, _b in smil:gmatch(pattern) do
         n = n + 1
     end
     return n
 end
 
-local multiline_smil = [[
-<smil>
-  <body>
-    <par id="s0">
-      <text src="../Author-[Series-1]Title.html#s0"/>
-      <audio src="../Audio/00001.mp4" clipBegin="0.000s" clipEnd="12.340s"/>
-    </par>
-  </body>
-</smil>
-]]
+local function count_manifest_overlays(opf_xml)
+    opf_xml = compact_xml(opf_xml)
+    local manifest_block = opf_xml:match("<manifest[^>]*>" .. RE_ANY_LAZY .. "</manifest>")
+    if not manifest_block then return 0, 0 end
+    local items = {}
+    local overlays = 0
+    for item_str in manifest_block:gmatch("<item([^>]-)/>") do
+        local id = item_str:match('id%s*=%s*"([^"]+)"')
+        local href = item_str:match('href%s*=%s*"([^"]+)"')
+        local mo = item_str:match('media%-overlay%s*=%s*"([^"]+)"')
+        if id and href then
+            items[id] = { href = href, mo = mo }
+        end
+    end
+    for id, item in pairs(items) do
+        if item.mo and items[item.mo] then
+            overlays = overlays + 1
+        end
+    end
+    return overlays, #manifest_block
+end
+
+local fixtures = arg[1] or "scripts/_fixtures"
+if not read_file(fixtures .. "/sample.smil") then
+    fixtures = "../scripts/_fixtures"
+end
+
+local failures = {}
+
+local smil, err = read_file(fixtures .. "/sample.smil")
+if not smil then
+    io.stderr:write("FAIL: missing fixture sample.smil: " .. tostring(err) .. "\n")
+    os.exit(1)
+end
+
+local opf = read_file(fixtures .. "/content.opf")
+if not opf then
+    table.insert(failures, "missing fixture content.opf")
+end
 
 local storyteller_member =
     "MediaOverlays/Author-[Series-1]Title_split_003.smil"
 local escaped = escape_unzip_member(storyteller_member)
-
-local broken = count_par(multiline_smil, "<par([^>]*)>(.-)</par>")
-local fixed = count_par(compact_xml(multiline_smil), "<par([^>]*)>" .. RE_ANY_LAZY .. "</par>")
-
-local failures = {}
-
-if broken ~= 0 then
-    table.insert(failures, "broken par pattern should miss multiline SMIL")
-end
-if fixed ~= 1 then
-    table.insert(failures, "expected 1 par after compact+fixed, got " .. fixed)
-end
 if escaped ~= "MediaOverlays/Author-[[]Series-1]Title_split_003.smil" then
     table.insert(failures, "unexpected unzip escape: " .. escaped)
+end
+
+local compact = compact_xml(smil)
+local par_count = count_par(compact, "<par([^>]*)>" .. RE_ANY_LAZY .. "</par>")
+if par_count ~= 23 then
+    table.insert(failures, "expected 23 par blocks in Storyteller sample SMIL, got " .. par_count)
+end
+
+if opf then
+    local overlays, manifest_len = count_manifest_overlays(opf)
+    if overlays ~= 27 then
+        table.insert(failures, "expected 27 overlay mappings in OPF, got " .. overlays)
+    end
+    if manifest_len < 1000 then
+        table.insert(failures, "OPF manifest block too short: " .. manifest_len)
+    end
 end
 
 if #failures > 0 then
@@ -63,4 +107,7 @@ if #failures > 0 then
     os.exit(1)
 end
 
-print("ok: multiline SMIL patterns and unzip member escaping")
+print(string.format(
+    "ok: Storyteller fixtures parsed (%d par, unzip escape verified)",
+    par_count
+))

--- a/dev/test_epubmediaoverlay_multiline.lua
+++ b/dev/test_epubmediaoverlay_multiline.lua
@@ -1,0 +1,104 @@
+#!/usr/bin/env luajit
+--[[--
+Smoke test: multiline Storyteller SMIL/OPF must parse under Lua patterns.
+
+Run from repo root:
+  luajit dev/test_epubmediaoverlay_multiline.lua
+
+No KOReader install required.
+--]]
+
+local RE_ANY_LAZY = "([%z\1-\255]-)"
+
+local function count(pattern, text)
+    local n = 0
+    for _ in text:gmatch(pattern) do
+        n = n + 1
+    end
+    return n
+end
+
+local multiline_smil = [[
+<smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+  <body>
+    <seq epub:textref="chapter.xhtml">
+      <par id="s0">
+        <text src="../chapter.xhtml#s0"/>
+        <audio src="../Audio/00001.mp4" clipBegin="0.000s" clipEnd="12.340s"/>
+      </par>
+      <par id="s1">
+        <text src="../chapter.xhtml#s1"/>
+        <audio src="../Audio/00001.mp4" clipBegin="12.340s" clipEnd="25.180s"/>
+      </par>
+    </seq>
+  </body>
+</smil>
+]]
+
+local multiline_opf = [[
+<package>
+  <manifest>
+    <item id="ch1" href="text/ch1.xhtml" media-type="application/xhtml+xml" media-overlay="mo1"/>
+    <item id="mo1" href="MediaOverlays/ch1.smil" media-type="application/smil+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+  </spine>
+</package>
+]]
+
+local multiline_html = [[
+<p>
+  <span id="s0">Première phrase.</span>
+  <span id="s1">Deuxième phrase.</span>
+</p>
+]]
+
+local broken_par = count("<par([^>]*)>(.-)</par>", multiline_smil)
+local fixed_par = count("<par([^>]*)>" .. RE_ANY_LAZY .. "</par>", multiline_smil)
+
+local broken_manifest = multiline_opf:match("<manifest[^>]*>(.-)</manifest>") or ""
+local fixed_manifest = multiline_opf:match("<manifest[^>]*>" .. RE_ANY_LAZY .. "</manifest>") or ""
+
+local broken_spine = multiline_opf:match("<spine[^>]*>(.-)</spine>") or ""
+local fixed_spine = multiline_opf:match("<spine[^>]*>" .. RE_ANY_LAZY .. "</spine>") or ""
+
+local broken_span = count('<span[^>]-id="([^"]+)"[^>]*>(.-)</span>', multiline_html)
+local fixed_span = count('<span[^>]-id="([^"]+)"[^>]*>' .. RE_ANY_LAZY .. '</span>', multiline_html)
+
+local failures = {}
+
+if broken_par ~= 0 then
+    table.insert(failures, "expected broken par pattern to miss multiline SMIL, got " .. broken_par)
+end
+if fixed_par ~= 2 then
+    table.insert(failures, "expected 2 par blocks, got " .. fixed_par)
+end
+if broken_manifest ~= "" then
+    table.insert(failures, "expected broken manifest pattern to miss multiline OPF")
+end
+if fixed_manifest == "" or not fixed_manifest:find("media-overlay") then
+    table.insert(failures, "expected fixed manifest pattern to capture overlay items")
+end
+if broken_spine ~= "" then
+    table.insert(failures, "expected broken spine pattern to miss multiline OPF")
+end
+if fixed_spine == "" or not fixed_spine:find("itemref") then
+    table.insert(failures, "expected fixed spine pattern to capture itemref")
+end
+if broken_span ~= 0 then
+    table.insert(failures, "expected broken span pattern to miss (if spans were multiline)")
+end
+if fixed_span ~= 2 then
+    table.insert(failures, "expected 2 sentence spans, got " .. fixed_span)
+end
+
+if #failures > 0 then
+    io.stderr:write("FAIL\n")
+    for _, msg in ipairs(failures) do
+        io.stderr:write("  - " .. msg .. "\n")
+    end
+    os.exit(1)
+end
+
+print("ok: multiline Storyteller SMIL/OPF patterns parse correctly")

--- a/epubmediaoverlay.lua
+++ b/epubmediaoverlay.lua
@@ -49,10 +49,9 @@ end
 -- detection passes but timing extraction yields zero entries).
 function EpubMediaOverlay:_escapeUnzipMember(path)
     if not path then return path end
-    -- Literal '[' -> '[[]', literal ']' -> '[]]' (Info-ZIP unzip convention).
-    path = path:gsub("%[", "[[]")
-    path = path:gsub("%]", "[]]")
-    return path
+    -- Info-ZIP: literal '[' is written as '[[]'. Do not escape ']' — doing so
+    -- corrupts the '[[]' token (']' inside it would become '[]]').
+    return path:gsub("%[", "[[]")
 end
 
 --- Pretty-printed XML puts newlines inside elements; collapse tag boundaries

--- a/epubmediaoverlay.lua
+++ b/epubmediaoverlay.lua
@@ -391,9 +391,20 @@ end
 -- Public API
 -- ---------------------------------------------------------------------------
 
-function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir)
+function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir, progress_callback)
     if not epub_path or not plugin_dir then
         return nil, "missing path or plugin_dir"
+    end
+
+    local function report(phase, current, total, detail)
+        if progress_callback then
+            pcall(progress_callback, {
+                phase = phase,
+                current = current,
+                total = total,
+                detail = detail,
+            })
+        end
     end
 
     self._epub_path = epub_path
@@ -445,8 +456,11 @@ function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir)
         end
     end
     local html_text_cache = {}
+    local audio_path_cache = {}
+    local total_smils = #ordered_overlays
 
-    for _, overlay_info in ipairs(ordered_overlays) do
+    for smil_idx, overlay_info in ipairs(ordered_overlays) do
+        report("smil", smil_idx, total_smils, overlay_info.smil_href)
         local smil_href = overlay_info.smil_href
         if not smil_href then goto continue end
 
@@ -465,12 +479,19 @@ function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir)
         local smil_base = smil_path:match("^(.*)/") or ""
         local timing_data = self:_parseSmil(smil_xml, smil_base)
 
-        -- Extract audio files, resolve sentence texts, and collect entries
+        -- Resolve audio paths once per distinct audio_src (Storyteller books
+        -- reference the same MP4 from thousands of <par> entries).
         for _, entry in ipairs(timing_data) do
             if entry.audio_src then
-                local audio_path = self:_extractAudioFile(epub_path, entry.audio_src, self._cache_dir)
-                if audio_path then
-                    entry.audio_path = audio_path
+                local ap = audio_path_cache[entry.audio_src]
+                if not ap then
+                    ap = self:_extractAudioFile(epub_path, entry.audio_src, self._cache_dir)
+                    audio_path_cache[entry.audio_src] = ap or false
+                elseif ap == false then
+                    ap = nil
+                end
+                if ap then
+                    entry.audio_path = ap
                 end
             end
             -- "../text/part0007.html#id12-s0" -> content doc + fragment id,
@@ -513,7 +534,13 @@ function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir)
     -- interleaves chapters.  Order here is narrative (SMIL) order; the
     -- caller groups by audio file and each group is internally monotonic.
 
-    logger.warn("EpubMediaOverlay: loaded", #all_timing_data, "timing entries")
+    local unique_audio = 0
+    for _ in pairs(audio_path_cache) do unique_audio = unique_audio + 1 end
+    report("done", #all_timing_data, total_smils,
+        string.format("%d timing, %d audio", #all_timing_data, unique_audio))
+
+    logger.warn("EpubMediaOverlay: loaded", #all_timing_data, "timing entries,",
+        unique_audio, "audio files")
     return all_timing_data
 end
 

--- a/epubmediaoverlay.lua
+++ b/epubmediaoverlay.lua
@@ -42,6 +42,26 @@ function EpubMediaOverlay:_runCommand(cmd)
     return out
 end
 
+--- Info-ZIP unzip treats [], ?, * as wildcards in archive member names.
+-- Storyteller titles often include bracketed series tags, e.g.
+-- "Author-[Series-1]Title(1955).html". Without escaping, unzip -p returns
+-- nothing even though unzip -l lists the SMIL files (which is why overlay
+-- detection passes but timing extraction yields zero entries).
+function EpubMediaOverlay:_escapeUnzipMember(path)
+    if not path then return path end
+    -- Literal '[' -> '[[]', literal ']' -> '[]]' (Info-ZIP unzip convention).
+    path = path:gsub("%[", "[[]")
+    path = path:gsub("%]", "[]]")
+    return path
+end
+
+--- Pretty-printed XML puts newlines inside elements; collapse tag boundaries
+-- so legacy `(.-)` patterns still work if RE_ANY_LAZY ever fails on-device.
+function EpubMediaOverlay:_compactXml(xml)
+    if not xml or xml == "" then return xml end
+    return xml:gsub(">%s+<", "><")
+end
+
 function EpubMediaOverlay:_ensureCacheDir(plugin_dir, epub_path)
     -- Use a hash of the epub path to create a stable cache directory
     local hash = self:_simpleHash(epub_path)
@@ -109,10 +129,11 @@ end
 
 function EpubMediaOverlay:_extractFromZip(epub_path, internal_path)
     -- Extract a single file from the EPUB using unzip
+    local zip_member = self:_escapeUnzipMember(internal_path)
     local cmd = string.format(
         'unzip -p "%s" "%s"',
         epub_path:gsub('"', '\\"'),
-        internal_path:gsub('"', '\\"')
+        zip_member:gsub('"', '\\"')
     )
     return self:_runCommand(cmd)
 end
@@ -140,6 +161,7 @@ function EpubMediaOverlay:_findOpfPath(epub_path)
 end
 
 function EpubMediaOverlay:_parseOpfManifest(opf_xml)
+    opf_xml = self:_compactXml(opf_xml)
     -- Extract manifest items from OPF.
     -- We need: items with media-overlay attributes, and the smil files they reference.
     local manifest = {}
@@ -195,6 +217,7 @@ end
 -- ---------------------------------------------------------------------------
 
 function EpubMediaOverlay:_parseSmil(smil_xml, smil_base_path)
+    smil_xml = self:_compactXml(smil_xml)
     -- Parse a SMIL file and return timing_data entries.
     -- SMIL structure:
     --   <smil>
@@ -340,10 +363,11 @@ function EpubMediaOverlay:_extractAudioFile(epub_path, internal_path, cache_dir)
     end
 
     -- Extract the file
+    local zip_member = self:_escapeUnzipMember(internal_path)
     local cmd = string.format(
         'unzip -o "%s" "%s" -d "%s" >/dev/null 2>&1',
         epub_path:gsub('"', '\\"'),
-        internal_path:gsub('"', '\\"'),
+        zip_member:gsub('"', '\\"'),
         cache_dir:gsub('"', '\\"')
     )
     os.execute(cmd)

--- a/epubmediaoverlay.lua
+++ b/epubmediaoverlay.lua
@@ -9,6 +9,10 @@ Caches extracted audio to persistent storage (not /tmp, to avoid RAM exhaustion)
 local logger = require("logger")
 local _ = require("gettext")
 
+-- Lua patterns: `.` does not match newlines. Storyteller (and many OPF
+-- producers) pretty-print SMIL/OPF with line breaks inside elements.
+local RE_ANY_LAZY = "([%z\1-\255]-)"
+
 local EpubMediaOverlay = {}
 
 function EpubMediaOverlay:new(o)
@@ -142,7 +146,7 @@ function EpubMediaOverlay:_parseOpfManifest(opf_xml)
     local manifest_items = {}
 
     -- Find the manifest section
-    local manifest_block = opf_xml:match("<manifest[^>]*>(.-)</manifest>")
+    local manifest_block = opf_xml:match("<manifest[^>]*>" .. RE_ANY_LAZY .. "</manifest>")
     if not manifest_block then
         logger.warn("EpubMediaOverlay: no manifest found in OPF")
         return nil
@@ -212,7 +216,7 @@ function EpubMediaOverlay:_parseSmil(smil_xml, smil_base_path)
     -- Find all <par> elements.  gmatch with two captures yields two loop
     -- values; the old single-variable loop bound only the attribute
     -- capture and threw away the body that holds <text>/<audio>.
-    for _par_attrs, par_block in smil_xml:gmatch("<par([^>]*)>(.-)</par>") do
+    for _par_attrs, par_block in smil_xml:gmatch("<par([^>]*)>" .. RE_ANY_LAZY .. "</par>") do
         -- Extract text src (match the <text> element specifically; a bare
         -- src= match would also hit <audio src=...>)
         local text_src = par_block:match('<text[^>]-src%s*=%s*"([^"]+)"')
@@ -221,7 +225,7 @@ function EpubMediaOverlay:_parseSmil(smil_xml, smil_base_path)
         -- src paths contain slashes)
         local audio_block = par_block:match("<audio([^>]-)/>")
         if not audio_block then
-            audio_block = par_block:match("<audio(.-)</audio>")
+            audio_block = par_block:match("<audio" .. RE_ANY_LAZY .. "</audio>")
         end
 
         if audio_block then
@@ -273,7 +277,7 @@ function EpubMediaOverlay:_extractSentenceTexts(epub_path, html_zip_path)
     local html = self:_extractFromZip(epub_path, html_zip_path)
     if not html or html == "" then return nil end
     local map = {}
-    for id, body in html:gmatch('<span[^>]-id="([^"]+)"[^>]*>(.-)</span>') do
+    for id, body in html:gmatch('<span[^>]-id="([^"]+)"[^>]*>' .. RE_ANY_LAZY .. '</span>') do
         if not map[id] then
             local txt = body:gsub("<[^>]->", "")
                 :gsub("&amp;", "&"):gsub("&lt;", "<"):gsub("&gt;", ">")
@@ -301,8 +305,8 @@ function EpubMediaOverlay:_loadChapterTitles(epub_path, opf_xml, opf_base)
     local titles = {}
     -- Flat scan is fine for the common non-nested navMap; with nesting the
     -- first label per target document still wins, which is what we want.
-    for block in ncx:gmatch("<navPoint.-</navPoint>") do
-        local label = block:match("<text>(.-)</text>")
+    for block in ncx:gmatch("<navPoint[%z\1-\255]-</navPoint>") do
+        local label = block:match("<text>" .. RE_ANY_LAZY .. "</text>")
         local src = block:match('src="([^"#]+)')
         if label and src then
             local base = src:match("([^/]+)$")
@@ -410,7 +414,7 @@ function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir)
     -- maps the reader's current position to a content document (used to
     -- start narration from the page the user is on).
     self._spine_hrefs = {}
-    local spine_block = opf_xml:match("<spine[^>]*>(.-)</spine>") or ""
+    local spine_block = opf_xml:match("<spine[^>]*>" .. RE_ANY_LAZY .. "</spine>") or ""
     for idref in spine_block:gmatch('<itemref[^>]-idref="([^"]+)"') do
         local it = manifest_items[idref]
         if it and it.href then

--- a/epubmediaoverlay.lua
+++ b/epubmediaoverlay.lua
@@ -61,11 +61,58 @@ function EpubMediaOverlay:_compactXml(xml)
     return xml:gsub(">%s+<", "><")
 end
 
+--- Fingerprint an EPUB so we invalidate extracted audio when the file is
+-- replaced in-place (same path, new Storyteller export). Path-only cache
+-- keys reused stale MP3/MP4 against fresh SMIL timings — highlights then
+-- tracked the new alignment while the old audio played (Readest was fine
+-- because it streams from the EPUB directly).
+function EpubMediaOverlay:_epubFingerprint(epub_path)
+    if not epub_path then return nil end
+    -- LuaFileSystem may be unavailable; fall back to shell stat.
+    local ok, lfs = pcall(require, "libs/libkoreader-lfs")
+    if ok and lfs and lfs.attributes then
+        local attr = lfs.attributes(epub_path)
+        if attr and attr.size and attr.modification then
+            return string.format("%d:%d", attr.size, attr.modification)
+        end
+    end
+    local out = self:_runCommand(string.format(
+        'stat -c "%%s:%%Y" "%s" 2>/dev/null || stat -f "%%z:%%m" "%s" 2>/dev/null',
+        epub_path:gsub('"', '\\"'), epub_path:gsub('"', '\\"')))
+    if out then
+        local fp = out:match("(%d+:%d+)")
+        if fp then return fp end
+    end
+    return nil
+end
+
 function EpubMediaOverlay:_ensureCacheDir(plugin_dir, epub_path)
     -- Use a hash of the epub path to create a stable cache directory
     local hash = self:_simpleHash(epub_path)
     local cache = plugin_dir .. "/cache/overlays/" .. hash
     os.execute("mkdir -p '" .. cache:gsub("'", "'\\''") .. "'")
+
+    local fp = self:_epubFingerprint(epub_path)
+    local meta_path = cache .. "/.epub_fingerprint"
+    local cached_fp
+    local f = io.open(meta_path, "r")
+    if f then
+        cached_fp = (f:read("*l") or ""):gsub("%s+$", "")
+        f:close()
+    end
+    if fp and cached_fp and cached_fp ~= "" and cached_fp ~= fp then
+        logger.warn("EpubMediaOverlay: EPUB changed (", cached_fp, "->", fp,
+            ") — wiping stale overlay cache", cache)
+        os.execute("rm -rf '" .. cache:gsub("'", "'\\''") .. "'")
+        os.execute("mkdir -p '" .. cache:gsub("'", "'\\''") .. "'")
+    end
+    if fp then
+        local wf = io.open(meta_path, "w")
+        if wf then
+            wf:write(fp)
+            wf:close()
+        end
+    end
     return cache
 end
 
@@ -298,15 +345,49 @@ end
 function EpubMediaOverlay:_extractSentenceTexts(epub_path, html_zip_path)
     local html = self:_extractFromZip(epub_path, html_zip_path)
     if not html or html == "" then return nil end
+    -- Stack-based scan so nested <span> (Storyteller wraps text in
+    -- <span id=sN><i><span lang=FR>…</span></i></span>) does not truncate
+    -- at the first inner </span>.
     local map = {}
-    for id, body in html:gmatch('<span[^>]-id="([^"]+)"[^>]*>' .. RE_ANY_LAZY .. '</span>') do
-        if not map[id] then
-            local txt = body:gsub("<[^>]->", "")
-                :gsub("&amp;", "&"):gsub("&lt;", "<"):gsub("&gt;", ">")
-                :gsub("&quot;", '"'):gsub("&#39;", "'"):gsub("&apos;", "'")
-                :gsub("&nbsp;", " ")
-                :gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", "")
-            if txt ~= "" then map[id] = txt end
+    local stack = {} -- { id=string|nil, parts={} }
+    local i = 1
+    local n = #html
+    while i <= n do
+        local s, e, attrs = html:find("<span([^>]*)>", i)
+        local cs, ce = html:find("</span>", i)
+        if s and (not cs or s < cs) then
+            if s > i and #stack > 0 then
+                table.insert(stack[#stack].parts, html:sub(i, s - 1))
+            end
+            local id = attrs and attrs:match('id%s*=%s*"([^"]+)"')
+            table.insert(stack, { id = id, parts = {} })
+            i = e + 1
+        elseif cs then
+            if cs > i and #stack > 0 then
+                table.insert(stack[#stack].parts, html:sub(i, cs - 1))
+            end
+            local finished = table.remove(stack)
+            i = ce + 1
+            if finished then
+                local body = table.concat(finished.parts)
+                -- Pass inner HTML up so parents keep nested text.
+                if #stack > 0 then
+                    table.insert(stack[#stack].parts, body)
+                end
+                if finished.id and not map[finished.id] then
+                    local txt = body:gsub("<[^>]->", "")
+                        :gsub("&amp;", "&"):gsub("&lt;", "<"):gsub("&gt;", ">")
+                        :gsub("&quot;", '"'):gsub("&#39;", "'"):gsub("&apos;", "'")
+                        :gsub("&nbsp;", " "):gsub("&#160;", " ")
+                        :gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", "")
+                    if txt ~= "" then map[finished.id] = txt end
+                end
+            end
+        else
+            if #stack > 0 and i <= n then
+                table.insert(stack[#stack].parts, html:sub(i))
+            end
+            break
         end
     end
     return map
@@ -430,23 +511,14 @@ function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir, progress_callback)
 
     logger.dbg("EpubMediaOverlay: found", self:_tableCount(overlay_manifest), "overlay entries")
 
-    -- Step 3: Parse SMIL files in narrative order.  pairs() iteration is
-    -- unordered, which interleaved chapters randomly; SMIL hrefs sort into
-    -- document order for every producer we have seen.
-    local ordered_overlays = {}
-    for _, info in pairs(overlay_manifest) do
-        table.insert(ordered_overlays, info)
-    end
-    table.sort(ordered_overlays, function(a, b)
-        return (a.smil_href or "") < (b.smil_href or "")
-    end)
-
     local all_timing_data = {}
     local opf_base = opf_path:match("^(.*)/") or ""
     self._chapter_titles = self:_loadChapterTitles(epub_path, opf_xml, opf_base)
     -- Spine order: crengine numbers DocFragments in spine order, so this
     -- maps the reader's current position to a content document (used to
-    -- start narration from the page the user is on).
+    -- start narration from the page the user is on). Also drives SMIL
+    -- parse order — string-sorting SMIL hrefs breaks when filenames are
+    -- not zero-padded the same way as the spine.
     self._spine_hrefs = {}
     local spine_block = opf_xml:match("<spine[^>]*>" .. RE_ANY_LAZY .. "</spine>") or ""
     for idref in spine_block:gmatch('<itemref[^>]-idref="([^"]+)"') do
@@ -455,6 +527,34 @@ function EpubMediaOverlay:loadFromEpub(epub_path, plugin_dir, progress_callback)
             table.insert(self._spine_hrefs, it.href:match("([^/]+)$") or it.href)
         end
     end
+
+    -- Step 3: Parse SMIL files in spine order (fallback: SMIL href sort).
+    local by_content = {}
+    for content_href, info in pairs(overlay_manifest) do
+        local base = (info.content_href or content_href):match("([^/]+)$")
+            or info.content_href or content_href
+        by_content[base] = info
+    end
+    local ordered_overlays = {}
+    local seen = {}
+    for _, base in ipairs(self._spine_hrefs) do
+        local info = by_content[base]
+        if info and not seen[info] then
+            table.insert(ordered_overlays, info)
+            seen[info] = true
+        end
+    end
+    for _, info in pairs(overlay_manifest) do
+        if not seen[info] then
+            table.insert(ordered_overlays, info)
+        end
+    end
+    if #ordered_overlays > 1 and #self._spine_hrefs == 0 then
+        table.sort(ordered_overlays, function(a, b)
+            return (a.smil_href or "") < (b.smil_href or "")
+        end)
+    end
+
     local html_text_cache = {}
     local audio_path_cache = {}
     local total_smils = #ordered_overlays

--- a/highlightmanager.lua
+++ b/highlightmanager.lua
@@ -85,11 +85,74 @@ function HighlightManager:highlightSentence(sentence, parsed_data)
     -- Returns true when the sentence was found and highlighted on the
     -- visible page (callers use this for read-along page advancement).
     if self.ui.rolling then
+        -- Storyteller / EPUB3 Media Overlays: prefer the SMIL fragment id
+        -- (Readest-style) over fuzzy on-screen text matching.
+        if sentence.fragment_id then
+            local ok = self:_highlightByFragmentId(doc, sentence.fragment_id)
+            if ok then return true end
+        end
         return self:_highlightSentenceRolling(sentence, parsed_data, doc)
     else
         -- PDF / paged mode: use view.highlight.temp
         return self:_highlightSentencePaging(sentence, parsed_data, doc)
     end
+end
+
+--- Highlight a SMIL sentence via its DOM id (e.g. "html39-s12").
+-- Works only when that content document is already the current CRe document.
+function HighlightManager:_highlightByFragmentId(doc, fragment_id)
+    if not doc or not fragment_id then return false end
+    local xp0
+    local ok_xp, norm = pcall(function()
+        return doc:getNormalizedXPointer("#" .. fragment_id)
+    end)
+    if not (ok_xp and norm and norm ~= false) then
+        return false
+    end
+    xp0 = norm
+    local xp1 = xp0
+
+    -- Expand to the full sentence/element when CRe supports it.
+    pcall(function()
+        local a, b = doc:extendXPointersToSentenceSegment(xp0, xp0)
+        if a and b then
+            xp0, xp1 = a, b
+        end
+    end)
+
+    local drawn
+    pcall(function()
+        drawn = doc:getTextFromXPointers(xp0, xp1, true)
+    end)
+    if not drawn or drawn == "" then
+        -- Fallback: DOM text + on-screen text match (still better than SMIL
+        -- text that may diverge from CRe's rendered form).
+        local node_text
+        pcall(function() node_text = doc:getTextFromXPointer(xp0) end)
+        pcall(function() doc:clearSelection() end)
+        if node_text and node_text ~= "" then
+            return self:_highlightSentenceRolling({ text = node_text }, nil, doc)
+        end
+        return false
+    end
+
+    self._selection_active = true
+    self.is_highlighting = true
+    self._pending_boxes = nil
+    local boxes
+    pcall(function()
+        boxes = doc:getScreenBoxesFromPositions(xp0, xp1, true)
+    end)
+    if boxes and #boxes > 0 and self.current_style ~= self.STYLES.INVERT then
+        self._pending_boxes = boxes
+        self:_ensureViewModule()
+        pcall(function() doc:clearSelection() end)
+        self._selection_active = false
+        UIManager:setDirty(self.ui.dialog or "all", "ui")
+    else
+        UIManager:setDirty(self.ui.dialog or "all", "ui")
+    end
+    return true
 end
 
 --[[--

--- a/highlightmanager.lua
+++ b/highlightmanager.lua
@@ -121,9 +121,12 @@ function HighlightManager:_highlightSentenceRolling(sentence, parsed_data, doc, 
     sent_text = sent_text
         :gsub("[\226\128\152-\226\128\155]", "'")    -- curly quotes → straight '
         :gsub("[\226\128\156-\226\128\159]", '"')    -- curly double quotes → straight "
+        :gsub("\194\171", '"'):gsub("\194\187", '"') -- « » guillemets → straight "
         :gsub("\226\128\147", "-")                    -- en-dash → hyphen
         :gsub("\226\128\148", "-")                    -- em-dash → hyphen
+        :gsub("\226\128\166", "...")                  -- ellipsis …
         :gsub("\194\160", " ")                        -- non-breaking space → space
+        :gsub("\194\173", "")                         -- soft hyphen
         :gsub("[\226\128\139\226\128\169]", "")       -- zero-width chars removed
         :gsub("\239\187\191", "")                     -- BOM removed
 
@@ -170,9 +173,12 @@ function HighlightManager:_highlightSentenceRolling(sentence, parsed_data, doc, 
                 lt = lt
                     :gsub("[\226\128\152-\226\128\155]", "'")
                     :gsub("[\226\128\156-\226\128\159]", '"')
+                    :gsub("\194\171", '"'):gsub("\194\187", '"')
                     :gsub("\226\128\147", "-")
                     :gsub("\226\128\148", "-")
+                    :gsub("\226\128\166", "...")
                     :gsub("\194\160", " ")
+                    :gsub("\194\173", "")
                     :gsub("[\226\128\139\226\128\169]", "")
                     :gsub("\239\187\191", "")
             end

--- a/main.lua
+++ b/main.lua
@@ -1310,13 +1310,7 @@ end
 function Audiobook:_startMediaPlaybackForDocument(doc_path)
     -- Try SMIL Media Overlays first
     if self:_hasMediaOverlays() then
-        UIManager:show(InfoMessage:new{
-            text = _("Loading Media Overlays..."),
-            timeout = 1,
-        })
-        UIManager:scheduleIn(0.5, function()
-            self:_startSmilPlayback(doc_path, nil, true)
-        end)
+        self:_startSmilPlayback(doc_path, nil, true)
         return
     end
 
@@ -1499,17 +1493,35 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
         return
     end
 
+    local loading_msg = InfoMessage:new{
+        text = _("Loading Media Overlays..."),
+        timeout = 3600,
+    }
+    UIManager:show(loading_msg)
+
     local parser = EpubMediaOverlay:new()
-    local timing_data, err = parser:loadFromEpub(doc_path, PLUGIN_PATH:sub(1, -2))
+    local plugin_dir = PLUGIN_PATH:sub(1, -2)
+    local timing_data, err = parser:loadFromEpub(doc_path, plugin_dir, function(prog)
+        if not prog then return end
+        if prog.phase == "smil" and prog.total then
+            loading_msg.text = T(_("Parsing overlays: %1 / %2"), prog.current, prog.total)
+        elseif prog.phase == "done" then
+            loading_msg.text = T(_("Loaded %1 timing entries"), prog.current)
+        end
+        UIManager:setDirty(nil, "ui")
+    end)
+
+    UIManager:close(loading_msg)
+
     if not timing_data then
         UIManager:show(InfoMessage:new{
             text = _("No Media Overlays found: ") .. tostring(err),
-            timeout = 3,
+            timeout = 4,
         })
         return
     end
 
-    -- Group timing entries by audio file, preserving narrative order.
+    -- Group timing entries by audio file
     -- Clip times restart at zero for every audio file, so each file plays
     -- with its own timing slice; the playlist mechanism chains the files
     -- and _playAudioFile installs the matching slice on every switch.
@@ -1546,6 +1558,8 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
                 table.insert(slot.chapters, {
                     title = titles[base] or base,
                     start_time = e.start_time,
+                    fragment_id = e.fragment_id,
+                    text_doc = e.text_doc,
                 })
             end
         end
@@ -1558,6 +1572,27 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
             or p:match("([^/]+)$") or p
         table.insert(playlist, { name = nm, path = p })
     end
+
+    -- Flat chapter list for the Chapters menu (all ~27 SMIL sections, not the
+    -- 4 MP4 playlist segments). Playlist still switches audio parts.
+    self._smil_overlay_chapters = {}
+    for _, p in ipairs(files) do
+        for _, ch in ipairs(by_file[p].chapters) do
+            table.insert(self._smil_overlay_chapters, {
+                title = ch.title,
+                start_time = ch.start_time,
+                audio_path = p,
+                fragment_id = ch.fragment_id,
+                text_doc = ch.text_doc,
+            })
+        end
+    end
+
+    UIManager:show(InfoMessage:new{
+        text = T(_("%1 sentences · %2 chapters · %3 audio parts"),
+            #timing_data, #self._smil_overlay_chapters, #files),
+        timeout = 3,
+    })
 
     -- Common startup logic used both for direct starts and after the resume prompt.
     local function do_start(chosen_entry)
@@ -1628,24 +1663,26 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
         -- If a specific start entry was requested, resume playback directly at
         -- that time instead of starting at 0:00 and seeking after a delay.
         local start_position = nil
-        if start_time and start_time > 1 then
+        if start_time then
             start_position = start_time
         end
         local started = self.media_sync:start(first, by_file[first].timing,
             by_file[first].chapters, nil, playlist, first, start_position)
         if started and start_position then
-            logger.warn("Audiobook: SMIL playback resumed at", start_position, "for", first:match("([^/]+)$"))
+            logger.warn("Audiobook: SMIL playback started at", start_position, "for", first:match("([^/]+)$"))
         end
-        -- When resuming or starting from a specific selection, move the book view
-        -- to the sentence being read so the screen matches the audio.
-        if started and start_position and self.media_sync.overlay_mode then
-            logger.warn("Audiobook: navigating view to sentence at", start_position)
-            local ok_nav, nav_err = pcall(function()
-                self.media_sync:navigateToSentenceAtTime(start_position)
+        -- Move the book view to the sentence being read.
+        if started and self.media_sync.overlay_mode then
+            local nav_time = start_position or 0
+            logger.warn("Audiobook: navigating view to sentence at", nav_time)
+            UIManager:scheduleIn(0.6, function()
+                local ok_nav, nav_err = pcall(function()
+                    self.media_sync:navigateToSentenceAtTime(nav_time)
+                end)
+                if not ok_nav then
+                    logger.warn("Audiobook: navigateToSentenceAtTime error:", nav_err)
+                end
             end)
-            if not ok_nav then
-                logger.warn("Audiobook: navigateToSentenceAtTime error:", nav_err)
-            end
         end
     end
 

--- a/main.lua
+++ b/main.lua
@@ -548,7 +548,20 @@ function Audiobook:addToMainMenu(menu_items)
                                 BtMediaControl.stop()
                             end
                         end,
-                        help_text = _("When enabled, play/pause/next/prev buttons on a Bluetooth headset or speaker will control playback. The connected device will also show playback status."),
+                        help_text = _("When enabled, play/pause/next/prev buttons on a Bluetooth headset or speaker will control playback. The connected device will also show playback status.\n\nNote: Kindle Paperwhite does not expose an AVRCP input device for AirPods stem presses (no btui / no media-key evdev). Stem play/pause is not available on this firmware; use the on-screen controls or Kindle buttons."),
+                    },
+                    {
+                        text = _("Reconnect BT on track change"),
+                        enabled_func = function()
+                            return Device.isKindle and Device:isKindle()
+                        end,
+                        checked_func = function()
+                            return self:getSetting("kindle_bt_reconnect_on_track", false)
+                        end,
+                        callback = function()
+                            self:toggleSetting("kindle_bt_reconnect_on_track", false)
+                        end,
+                        help_text = _("Kindle + AirPods: when enabled, each playlist/Storyteller audio-file boundary runs a Bluetooth Disconnect→Connect cycle before the next file starts (~5–10 s gap). Off by default; the plugin still keeps a silent A2DP keepalive across the gap. Turn this on only if audio goes silent at chapter/chunk transitions."),
                     },
                     {
                         text_func = function()
@@ -784,7 +797,7 @@ function Audiobook:addToMainMenu(menu_items)
                         end,
                     },
                     {
-                        text = _("Follow page turns in aligned audiobook"),
+                        text = _("Follow narration page (aligned)"),
                         enabled_func = function() return (self.ui and self.ui.document) or false end,
                         checked_func = function()
                             return self:getSetting("media_follow_page_turn", true)
@@ -792,7 +805,18 @@ function Audiobook:addToMainMenu(menu_items)
                         callback = function()
                             self:toggleSetting("media_follow_page_turn", true)
                         end,
-                        help_text = _("When enabled (default), an aligned audiobook will automatically turn pages to keep the narration in view, and manually turning the page will seek narration to the new page. When disabled, pages do not auto-follow and manual turns do not seek audio; only the currently visible text is highlighted."),
+                        help_text = _("When enabled (default), the book view auto-turns to keep the current narration sentence on screen while you stay with the read-aloud. Manually turning a page never seeks or restarts audio: highlighting pauses and a “Return to read-aloud” cue appears until you jump back or the narration catches up."),
+                    },
+                    {
+                        text = _("Keep status bars during read-aloud"),
+                        enabled_func = function() return (self.ui and self.ui.document) or false end,
+                        checked_func = function()
+                            return self:getSetting("keep_reader_status_bars", false)
+                        end,
+                        callback = function()
+                            self:toggleSetting("keep_reader_status_bars", false)
+                        end,
+                        help_text = _("When enabled, the minimized read-aloud mini player sits above KOReader’s bottom status bar (and does not cover it). The CRE alt status bar at the top is left alone. When disabled (default), the mini player sits at the very bottom of the screen."),
                     },
                     {
                         text = _("Sleep timer"),
@@ -1675,11 +1699,7 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
                 "start_time=", start_time)
         end
 
-        pcall(function()
-            if self:getSetting("bt_media_control", true) and BtMediaControl then
-                BtMediaControl.start(self)
-            end
-        end)
+        pcall(function() self:_ensureBtMediaControl() end)
 
         -- Cache parser/timing for page-follow and selection restarts.
         -- If we are switching to a different EPUB, drop the resolved-xpointer
@@ -1734,9 +1754,24 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
             end
             -- Extra seek after start: some Kindle backends ignore #t= on the
             -- first play(); seekToTime restarts at the correct clip time.
+            -- Skip when MediaEngine already started at start_position — a
+            -- redundant seek-by-restart kills A2DP (AirPods: brief sound then silence).
             if start_position and start_position > 0 and self.media_sync.seekToTime then
-                UIManager:scheduleIn(0.4, function()
-                    pcall(function() self.media_sync:seekToTime(start_position) end)
+                UIManager:scheduleIn(0.8, function()
+                    pcall(function()
+                        if not self.media_sync or not self.media_sync.media_engine then return end
+                        local eng = self.media_sync.media_engine
+                        if not eng.is_playing or eng.is_paused then return end
+                        local pos = eng:getPosition() or 0
+                        local started_at = eng._seek_offset or 0
+                        if math.abs(pos - start_position) < 1.0
+                            or math.abs(started_at - start_position) < 0.25 then
+                            logger.warn("Audiobook: skip post-start seek (already near",
+                                start_position, "pos=", pos, "seek_offset=", started_at, ")")
+                            return
+                        end
+                        self.media_sync:seekToTime(start_position)
+                    end)
                 end)
             end
             if Time then
@@ -1861,11 +1896,7 @@ function Audiobook:_playAudioFile(file_path, playlist_files)
         local slot = self._smil_by_file[file_path]
         self.media_sync:start(file_path, slot.timing, slot.chapters, nil,
             playlist_files or self.media_sync.playlist_files, file_path)
-        pcall(function()
-            if self:getSetting("bt_media_control", true) and BtMediaControl then
-                BtMediaControl.start(self)
-            end
-        end)
+        pcall(function() self:_ensureBtMediaControl() end)
         return
     end
 
@@ -2910,6 +2941,22 @@ function Audiobook:stopReadAlong()
     pcall(function() self.tts_engine:forceKillAll() end)
 end
 
+--- Ensure headset media buttons (AirPods stem) are listened for.
+-- On Kindle, auto-enable the setting: BlueZ AVRCP is absent and the stem
+-- only works if we advertise as an AVRCP target + scan for media input.
+function Audiobook:_ensureBtMediaControl()
+    if not BtMediaControl then return end
+    if Device.isKindle and Device:isKindle() then
+        if not self:getSetting("bt_media_control", true) then
+            self:setSetting("bt_media_control", true)
+            logger.warn("Audiobook: enabled bt_media_control for Kindle headset buttons")
+        end
+    end
+    if self:getSetting("bt_media_control", true) then
+        BtMediaControl.start(self)
+    end
+end
+
 function Audiobook:pauseReadAlong()
     if not self._init_ok then return end
     -- Pause media playback if active
@@ -2929,11 +2976,13 @@ function Audiobook:resumeReadAlong()
     if not self._init_ok then return end
     -- Resume media playback if active
     if self.media_sync and self.media_sync.state == "paused" then
+        pcall(function() self:_ensureBtMediaControl() end)
         pcall(function() self.media_sync:resume() end)
         pcall(function() BtMediaControl.sendPlaybackStatus("playing") end)
         return
     end
     if self.sync_controller then
+        pcall(function() self:_ensureBtMediaControl() end)
         pcall(function() self.sync_controller:resume() end)
         pcall(function() BtMediaControl.sendPlaybackStatus("playing") end)
     end
@@ -3036,9 +3085,19 @@ end
 
 function Audiobook:onMediaPlayPause()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() then
+    -- Prefer media_sync (Storyteller / audiobook) over TTS sync_controller.
+    local media_active = self.media_sync and self.media_sync.state ~= "stopped"
+    if media_active then
+        if self.media_sync.state == "playing" then
+            self:pauseReadAlong()
+        elseif self.media_sync.state == "paused" then
+            self:resumeReadAlong()
+        end
+        return true
+    end
+    if self.sync_controller and self.sync_controller:isPlaying() then
         self:pauseReadAlong()
-    elseif self.sync_controller:isPaused() then
+    elseif self.sync_controller and self.sync_controller:isPaused() then
         self:resumeReadAlong()
     end
     return true
@@ -3046,17 +3105,13 @@ end
 
 function Audiobook:onMediaPlay()
     if not self._init_ok then return true end
-    if self.sync_controller:isPaused() then
-        self:resumeReadAlong()
-    end
+    self:resumeReadAlong()
     return true
 end
 
 function Audiobook:onMediaPause()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() then
-        self:pauseReadAlong()
-    end
+    self:pauseReadAlong()
     return true
 end
 
@@ -3069,7 +3124,11 @@ end
 
 function Audiobook:onMediaNext()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() or self.sync_controller:isPaused() then
+    if self.media_sync and self.media_sync.state ~= "stopped" then
+        self.media_sync:nextChapter()
+        return true
+    end
+    if self.sync_controller and (self.sync_controller:isPlaying() or self.sync_controller:isPaused()) then
         self.sync_controller:nextSentence()
     end
     return true
@@ -3077,7 +3136,11 @@ end
 
 function Audiobook:onMediaPrev()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() or self.sync_controller:isPaused() then
+    if self.media_sync and self.media_sync.state ~= "stopped" then
+        self.media_sync:prevChapter()
+        return true
+    end
+    if self.sync_controller and (self.sync_controller:isPlaying() or self.sync_controller:isPaused()) then
         self.sync_controller:prevSentence()
     end
     return true
@@ -3144,6 +3207,7 @@ function Audiobook:_handlePageTurnFollow()
     if not self.media_sync.overlay_mode then return end
     if self.media_sync.state ~= self.media_sync.STATE.PLAYING
        and self.media_sync.state ~= self.media_sync.STATE.PAUSED then
+        self._readaloud_browsing_away = false
         self:_hideReturnToReadAloudButton()
         return
     end
@@ -3163,61 +3227,17 @@ function Audiobook:_handlePageTurnFollow()
     local ok, err = pcall(function()
         local on_audio_page = self:_currentAudioSentenceVisible()
 
-        if self.media_sync.state == self.media_sync.STATE.PAUSED then
-            -- Browsing while paused: drop the stale highlight (it would
-            -- otherwise be redrawn at the wrong place on the new page) and
-            -- offer a Readest-style return button.
-            pcall(function() self.media_sync:clearSentenceHighlight() end)
-            if on_audio_page then
-                self:_hideReturnToReadAloudButton()
-            else
-                self:_showReturnToReadAloudButton()
-            end
-            return
-        end
-
-        -- PLAYING
-        if not on_audio_page then
+        -- Manual page turns must NEVER seek/restart audio. Audio keeps
+        -- playing; we only pause highlighting and show a return cue
+        -- (Readest-style) until the user jumps back or narration catches up.
+        if on_audio_page then
+            self._readaloud_browsing_away = false
+            self:_hideReturnToReadAloudButton()
+        else
+            self._readaloud_browsing_away = true
             pcall(function() self.media_sync:clearSentenceHighlight() end)
             self:_showReturnToReadAloudButton()
-        else
-            self:_hideReturnToReadAloudButton()
         end
-
-        if not self:getSetting("media_follow_page_turn", true) then return end
-
-        local start_entry = self:_findCurrentPageSmilEntry()
-        if not start_entry or not start_entry.audio_path then return end
-
-        -- If the current audio position is already inside the current page's
-        -- narration range, do not seek.
-        local current_path = self.media_sync.media_engine and self.media_sync.media_engine.current_path
-        local current_pos = self.media_sync.media_engine and self.media_sync.media_engine:getPosition()
-        if current_path == start_entry.audio_path and current_pos then
-            local page_end = start_entry.end_time or start_entry.start_time
-            for _, e in ipairs(self._smil_timing_data or {}) do
-                if e.audio_path == current_path and e.text_doc == start_entry.text_doc then
-                    if e.end_time and e.end_time > page_end then
-                        page_end = e.end_time
-                    end
-                end
-            end
-            if current_pos >= start_entry.start_time and current_pos <= page_end then
-                return
-            end
-        end
-
-        if Time then
-            self._suppress_media_sync_auto_page_follow = Time.now() + Time.s(3.0)
-        end
-
-        if current_path and current_path ~= start_entry.audio_path then
-            self.media_sync:stop()
-            self:_startSmilPlayback(self.ui.document.file_path or self.ui.document.file, start_entry, false)
-        else
-            self.media_sync:seekToTime(start_entry.start_time)
-        end
-        self:_hideReturnToReadAloudButton()
     end)
     self._in_handle_page_turn_follow = false
     if not ok then

--- a/main.lua
+++ b/main.lua
@@ -1484,41 +1484,57 @@ end
 
 function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
     allow_resume = (allow_resume == true)
-    local ok, EpubMediaOverlay = pcall(dofile, PLUGIN_PATH .. "epubmediaoverlay.lua")
-    if not ok or not EpubMediaOverlay then
-        UIManager:show(InfoMessage:new{
-            text = _("Failed to load EPUB Media Overlay parser."),
-            timeout = 3,
-        })
-        return
-    end
 
-    local loading_msg = InfoMessage:new{
-        text = _("Loading Media Overlays..."),
-        timeout = 3600,
-    }
-    UIManager:show(loading_msg)
-
-    local parser = EpubMediaOverlay:new()
-    local plugin_dir = PLUGIN_PATH:sub(1, -2)
-    local timing_data, err = parser:loadFromEpub(doc_path, plugin_dir, function(prog)
-        if not prog then return end
-        if prog.phase == "smil" and prog.total then
-            loading_msg.text = T(_("Parsing overlays: %1 / %2"), prog.current, prog.total)
-        elseif prog.phase == "done" then
-            loading_msg.text = T(_("Loaded %1 timing entries"), prog.current)
+    -- Reuse a just-loaded cache (e.g. "Play aligned from here") so we don't
+    -- re-parse the whole EPUB and invalidate start_entry.audio_path keys.
+    local parser = self._smil_parser
+    local timing_data = self._smil_timing_data
+    if not (parser and timing_data and self._smil_doc_path == doc_path) then
+        local ok, EpubMediaOverlay = pcall(dofile, PLUGIN_PATH .. "epubmediaoverlay.lua")
+        if not ok or not EpubMediaOverlay then
+            UIManager:show(InfoMessage:new{
+                text = _("Failed to load EPUB Media Overlay parser."),
+                timeout = 3,
+            })
+            return
         end
-        UIManager:setDirty(nil, "ui")
-    end)
 
-    UIManager:close(loading_msg)
+        local loading_msg = InfoMessage:new{
+            text = _("Loading Media Overlays..."),
+            timeout = 3600,
+        }
+        UIManager:show(loading_msg)
+        UIManager:forceRePaint()
 
-    if not timing_data then
-        UIManager:show(InfoMessage:new{
-            text = _("No Media Overlays found: ") .. tostring(err),
-            timeout = 4,
-        })
-        return
+        parser = EpubMediaOverlay:new()
+        local plugin_dir = PLUGIN_PATH:sub(1, -2)
+        local err
+        timing_data, err = parser:loadFromEpub(doc_path, plugin_dir, function(prog)
+            if not prog then return end
+            if prog.phase == "smil" and prog.total then
+                local name = prog.detail and tostring(prog.detail):match("([^/]+)$") or ""
+                loading_msg.text = T(_("Parsing overlays: %1 / %2\n%3"),
+                    prog.current, prog.total, name)
+            elseif prog.phase == "done" then
+                loading_msg.text = T(_("Loaded %1 timing entries"), prog.current)
+            end
+            -- forceRePaint so e-ink shows live progress during the blocking parse.
+            UIManager:setDirty(loading_msg, function()
+                return "ui", loading_msg.dimen
+            end)
+            UIManager:forceRePaint()
+        end)
+
+        UIManager:close(loading_msg)
+        UIManager:forceRePaint()
+
+        if not timing_data then
+            UIManager:show(InfoMessage:new{
+                text = _("No Media Overlays found: ") .. tostring(err),
+                timeout = 4,
+            })
+            return
+        end
     end
 
     -- Group timing entries by audio file
@@ -1666,23 +1682,44 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
         if start_time then
             start_position = start_time
         end
+        -- Suppress page-crawl auto-follow until we have jumped to the target
+        -- sentence.  Without this, a late seek / failed #id scroll triggers
+        -- GotoViewRel(1) on every sentence and freezes the Kindle touch UI.
+        if Time then
+            self._suppress_media_sync_auto_page_follow = Time.now() + Time.s(4.0)
+        end
+
         local started = self.media_sync:start(first, by_file[first].timing,
             by_file[first].chapters, nil, playlist, first, start_position)
         if started and start_position then
             logger.warn("Audiobook: SMIL playback started at", start_position, "for", first:match("([^/]+)$"))
         end
-        -- Move the book view to the sentence being read.
+        -- Jump the book view straight to the chosen SMIL entry (by fragment),
+        -- not a page-by-page crawl and not a fragile start_time lookup.
         if started and self.media_sync.overlay_mode then
-            local nav_time = start_position or 0
-            logger.warn("Audiobook: navigating view to sentence at", nav_time)
-            UIManager:scheduleIn(0.6, function()
-                local ok_nav, nav_err = pcall(function()
-                    self.media_sync:navigateToSentenceAtTime(nav_time)
-                end)
-                if not ok_nav then
-                    logger.warn("Audiobook: navigateToSentenceAtTime error:", nav_err)
+            logger.warn("Audiobook: navigating view to entry",
+                chosen_entry and chosen_entry.fragment_id, "t=", start_position)
+            local ok_nav, nav_err = pcall(function()
+                if chosen_entry and chosen_entry.fragment_id then
+                    self.media_sync:navigateToSentenceEntry(chosen_entry)
+                else
+                    self.media_sync:navigateToSentenceAtTime(start_position or 0)
                 end
             end)
+            if not ok_nav then
+                logger.warn("Audiobook: navigate to entry error:", nav_err)
+            end
+            -- Extra seek after start: some Kindle backends ignore #t= on the
+            -- first play(); seekToTime restarts at the correct clip time.
+            if start_position and start_position > 0 and self.media_sync.seekToTime then
+                UIManager:scheduleIn(0.4, function()
+                    pcall(function() self.media_sync:seekToTime(start_position) end)
+                end)
+            end
+            if Time then
+                self._suppress_media_sync_auto_page_follow = Time.now() + Time.s(2.0)
+            end
+            self:_hideReturnToReadAloudButton()
         end
     end
 
@@ -2324,7 +2361,137 @@ end
 
 function Audiobook:_fragmentFromXPointer(xp)
     if type(xp) ~= "string" then return nil end
+    -- CRe selections rarely carry a trailing #id; Storyteller spans show up as
+    -- [@id='html39-s12'] inside the internal xpointer.
     return xp:match("#([^#]+)$")
+        or xp:match("%[@id%s*=%s*['\"]([^'\"]+)['\"]%]")
+        or xp:match("%[@id%s*=%s*([^%]]+)%]")
+end
+
+function Audiobook:_normalizeSelText(text)
+    if not text or text == "" then return "" end
+    return text
+        :gsub("[\n\r]+", " ")
+        :gsub("%s+", " ")
+        :gsub("^%s*", "")
+        :gsub("%s*$", "")
+        :gsub("[\226\128\152-\226\128\155]", "'")
+        :gsub("[\226\128\156-\226\128\159]", '"')
+        :gsub("\194\171", '"'):gsub("\194\187", '"')
+        :gsub("\226\128\147", "-"):gsub("\226\128\148", "-")
+        :gsub("\226\128\166", "...")
+end
+
+function Audiobook:_matchSmilEntryFromSelection(selected_text, timing_data, parser)
+    -- Resolve the SMIL timing entry that best matches a user selection.
+    -- Prefer fragment id from the CRe xpointer, then scored text matches in
+    -- the current DocFragment (never the first hit earlier in the book).
+    if not selected_text or not timing_data then return nil end
+
+    local frag = self:_fragmentFromXPointer(selected_text.pos0)
+        or self:_fragmentFromXPointer(selected_text.pos1)
+    if frag then
+        for _, e in ipairs(timing_data) do
+            if e.fragment_id == frag then
+                logger.warn("Audiobook: matched selection via fragment id", frag)
+                return e
+            end
+        end
+    end
+
+    local sel_text = self:_normalizeSelText(selected_text.text)
+    if sel_text == "" then return nil end
+
+    -- Expand short selections with nearby on-screen text.
+    local word_count = 0
+    for _ in sel_text:gmatch("%S+") do word_count = word_count + 1 end
+    if word_count <= 3 and selected_text.pos0 and self.ui and self.ui.document
+        and self.ui.document.getScreenPositionFromXPointer
+        and self.ui.document.getTextFromPositions then
+        local ok_y, screen_y = pcall(
+            self.ui.document.getScreenPositionFromXPointer,
+            self.ui.document, selected_text.pos0)
+        if ok_y and screen_y then
+            local ScreenDev = Device.screen
+            local y0 = math.max(0, screen_y - 60)
+            local y1 = math.min(ScreenDev:getHeight(), screen_y + 100)
+            local ok_t, res = pcall(
+                self.ui.document.getTextFromPositions,
+                self.ui.document,
+                {x = 0, y = y0},
+                {x = ScreenDev:getWidth(), y = y1},
+                true)
+            if ok_t and res and res.text and #res.text > #sel_text then
+                local expanded = self:_normalizeSelText(res.text)
+                if expanded:find(sel_text, 1, true) then
+                    sel_text = expanded
+                end
+            end
+        end
+    end
+
+    local cur_xp = self.ui and self.ui.document and self.ui.document:getXPointer()
+    local frag_idx = cur_xp and tonumber(cur_xp:match("DocFragment%[(%d+)%]"))
+    local spine = parser and parser._spine_hrefs or {}
+    local cur_base = frag_idx and spine[frag_idx]
+
+    local function in_current_doc(e)
+        if not cur_base then return true end
+        return e.text_doc and e.text_doc:match("([^/]+)$") == cur_base
+    end
+
+    -- Needle: prefer a distinctive prefix of the selection.
+    local needle = sel_text
+    if #needle > 80 then needle = needle:sub(1, 80) end
+
+    local sel_y = nil
+    if selected_text.pos0 and self.ui and self.ui.document
+        and self.ui.document.getScreenPositionFromXPointer then
+        local ok_y, y = pcall(
+            self.ui.document.getScreenPositionFromXPointer,
+            self.ui.document, selected_text.pos0)
+        if ok_y then sel_y = y end
+    end
+
+    local best, best_score = nil, -1
+    for _, e in ipairs(timing_data) do
+        if in_current_doc(e) and e.text and e.text ~= "" then
+            local et = self:_normalizeSelText(e.text)
+            local score = 0
+            if et == sel_text then
+                score = 10000
+            elseif et:find(sel_text, 1, true) then
+                score = 5000 + math.min(#sel_text, 200)
+            elseif sel_text:find(et, 1, true) then
+                score = 4000 + math.min(#et, 200)
+            elseif et:find(needle, 1, true) then
+                score = 2000 + math.min(#needle, 80)
+            elseif needle:find(et:sub(1, math.min(40, #et)), 1, true) then
+                score = 1000
+            end
+            if score > 0 and sel_y and e.fragment_id and self.ui.document.getScreenPositionFromXPointer then
+                local ok_fy, fy = pcall(
+                    self.ui.document.getScreenPositionFromXPointer,
+                    self.ui.document, "#" .. e.fragment_id)
+                if ok_fy and fy then
+                    -- Closer on screen → higher score (up to +500).
+                    local dist = math.abs(fy - sel_y)
+                    score = score + math.max(0, 500 - math.floor(dist / 2))
+                end
+            end
+            if score > best_score then
+                best_score = score
+                best = e
+            end
+        end
+    end
+
+    if best then
+        logger.warn("Audiobook: matched selection by scored text",
+            best.fragment_id, "score", best_score, "needle", needle:sub(1, 60))
+        return best
+    end
+    return nil
 end
 
 function Audiobook:startAlignedAudioFromSelection(selected_text)
@@ -2351,14 +2518,7 @@ function Audiobook:startAlignedAudioFromSelection(selected_text)
         return
     end
 
-    UIManager:show(InfoMessage:new{
-        text = _("Loading Media Overlays..."),
-        timeout = 1,
-    })
-
-    UIManager:scheduleIn(0.5, function()
-        self:_startSmilPlaybackFromSelection(doc_path, selected_text, false)
-    end)
+    self:_startSmilPlaybackFromSelection(doc_path, selected_text, false)
 end
 
 function Audiobook:_startSmilPlaybackFromSelection(doc_path, selected_text, allow_resume)
@@ -2387,9 +2547,30 @@ function Audiobook:_startSmilPlaybackFromSelection(doc_path, selected_text, allo
         self._smil_doc_path = nil
     end
     if not parser or not timing_data then
+        local loading_msg = InfoMessage:new{
+            text = _("Loading Media Overlays..."),
+            timeout = 3600,
+        }
+        UIManager:show(loading_msg)
+        UIManager:forceRePaint()
         parser = EpubMediaOverlay:new()
         local err
-        timing_data, err = parser:loadFromEpub(doc_path, PLUGIN_PATH:sub(1, -2))
+        timing_data, err = parser:loadFromEpub(doc_path, PLUGIN_PATH:sub(1, -2), function(prog)
+            if not prog then return end
+            if prog.phase == "smil" and prog.total then
+                local name = prog.detail and tostring(prog.detail):match("([^/]+)$") or ""
+                loading_msg.text = T(_("Parsing overlays: %1 / %2\n%3"),
+                    prog.current, prog.total, name)
+            elseif prog.phase == "done" then
+                loading_msg.text = T(_("Loaded %1 timing entries"), prog.current)
+            end
+            UIManager:setDirty(loading_msg, function()
+                return "ui", loading_msg.dimen
+            end)
+            UIManager:forceRePaint()
+        end)
+        UIManager:close(loading_msg)
+        UIManager:forceRePaint()
         if not timing_data then
             UIManager:show(InfoMessage:new{
                 text = _("No Media Overlays found: ") .. tostring(err),
@@ -2403,86 +2584,21 @@ function Audiobook:_startSmilPlaybackFromSelection(doc_path, selected_text, allo
         self._smil_doc_path = doc_path
     end
 
-    local start_entry = nil
-    if selected_text then
-        local frag = self:_fragmentFromXPointer(selected_text.pos0)
-            or self:_fragmentFromXPointer(selected_text.pos1)
-        if frag then
-            for _, e in ipairs(timing_data) do
-                if e.fragment_id == frag then
-                    start_entry = e
-                    break
-                end
-            end
-        end
-    end
-
-    if not start_entry and selected_text and selected_text.text then
-        -- CRe xpointer selections do not carry a #fragment id. Fall back to
-        -- matching the selected text against the sentence texts in the current
-        -- content document so "Play aligned audiobook from here" actually
-        -- starts near the selection.
-        local sel_text = selected_text.text
-            :gsub("[\n\r]+", " ")
-            :gsub("%s+", " ")
-            :gsub("^%s*", "")
-            :gsub("%s*$", "")
-        if sel_text ~= "" then
-            -- Use the first few words; a full sentence is more reliable than a
-            -- single word that may appear many times.
-            local first_words = sel_text:match("^%S+%s+%S+%s+%S+%s+%S+%s+%S+")
-                or sel_text:match("^%S+%s+%S+%s+%S+")
-                or sel_text:match("^%S+")
-                or sel_text
-            -- Prefer entries in the current document.
-            local cur_xp = self.ui and self.ui.document
-                and self.ui.document:getXPointer()
-            local frag_idx = cur_xp and tonumber(cur_xp:match("DocFragment%[(%d+)%]"))
-            local spine = parser._spine_hrefs or {}
-            local function in_current_doc(e)
-                if not frag_idx or not spine[frag_idx] then return true end
-                local base = spine[frag_idx]
-                return e.text_doc and e.text_doc:match("([^/]+)$") == base
-            end
-            for pass = 1, 2 do
-                for _, e in ipairs(timing_data) do
-                    local use_entry = (pass == 1) and in_current_doc(e) or true
-                    if use_entry and e.text
-                        and e.text:find(first_words, 1, true) then
-                        start_entry = e
-                        logger.warn("Audiobook: matched selection to SMIL entry by text", e.fragment_id)
-                        break
-                    end
-                end
-                if start_entry then break end
-            end
-        end
-    end
+    local start_entry = self:_matchSmilEntryFromSelection(selected_text, timing_data, parser)
 
     if not start_entry then
         -- Fall back to the first timing entry for the current page.
-        local cur_xp = self.ui and self.ui.document
-            and self.ui.document:getXPointer()
-        local frag_idx = cur_xp and tonumber(cur_xp:match("DocFragment%[(%d+)%]"))
-        local spine = parser._spine_hrefs or {}
-        if frag_idx and spine[frag_idx] then
-            for si = frag_idx, #spine do
-                local base = spine[si]
-                for _, e in ipairs(timing_data) do
-                    if e.audio_path and e.text_doc
-                        and (e.text_doc:match("([^/]+)$") == base) then
-                        start_entry = e
-                        break
-                    end
-                end
-                if start_entry then break end
-            end
-        end
+        start_entry = self:_findCurrentPageSmilEntry()
     end
 
     if not start_entry then
         start_entry = timing_data[1]
     end
+
+    logger.warn("Audiobook: Play-from-here entry",
+        start_entry and start_entry.fragment_id,
+        "t=", start_entry and start_entry.start_time,
+        "doc=", start_entry and start_entry.text_doc)
 
     if allow_resume then
         self:_promptResumeAlignedPlayback(doc_path, timing_data, start_entry, function(chosen_entry)
@@ -2495,22 +2611,42 @@ end
 
 function Audiobook:startReadAlongFromWord(word, context)
     if not self._init_ok then self:_showInitError(); return end
-    local page_text = self:getCurrentPageText()
+    if not self.tts_engine then
+        local hint = ""
+        if self:_hasMediaOverlays() then
+            hint = _("\n\nThis book has embedded narration — use \"Play aligned audiobook from here\" instead.")
+        end
+        UIManager:show(InfoMessage:new{
+            text = _("TTS engine is not available.") .. hint,
+            timeout = 6,
+        })
+        return
+    end
+    if not self:_audioOutputReady() then return end
+
+    local ok_page, page_text = pcall(function() return self:getCurrentPageText() end)
+    if not ok_page then
+        logger.warn("Audiobook: getCurrentPageText error:", page_text)
+        page_text = nil
+    end
     if not page_text or page_text == "" then
         -- Try to get text from the dictionary lookup context instead
         if self.ui.highlight and self.ui.highlight.selected_text then
             local selected = self.ui.highlight.selected_text
-            -- Get surrounding context
             if selected.text then
                 page_text = selected.text
             end
         end
     end
-    
+
     if not page_text or page_text == "" then
+        local hint = ""
+        if self:_hasMediaOverlays() then
+            hint = _("\n\nFor this read-aloud EPUB, use \"Play aligned audiobook from here\".")
+        end
         UIManager:show(InfoMessage:new{
-            text = _("Could not retrieve page text. This document type may not be supported yet."),
-            timeout = 3,
+            text = _("Could not retrieve page text for TTS.") .. hint,
+            timeout = 5,
         })
         return
     end
@@ -2932,13 +3068,51 @@ function Audiobook:onPageUpdate(cur_page, prev_page)
     self:_handlePageTurnFollow()
 end
 
+function Audiobook:_currentAudioSentenceVisible()
+    -- True when the sentence currently tied to the audio position appears on
+    -- the visible page (so we should keep the highlight / hide "return").
+    if not self.media_sync or not self.media_sync.overlay_mode then return false end
+    local idx = self.media_sync._current_sentence_idx
+    local sent = idx and self.media_sync.timing_data and self.media_sync.timing_data[idx]
+    if not sent or not sent.text then return false end
+    local page_text = self:getCurrentPageText()
+    if not page_text or page_text == "" then return false end
+    local needle = self:_normalizeSelText(sent.text)
+    if #needle > 48 then needle = needle:sub(1, 48) end
+    page_text = self:_normalizeSelText(page_text)
+    return needle ~= "" and page_text:find(needle, 1, true) ~= nil
+end
+
+function Audiobook:_showReturnToReadAloudButton()
+    -- Drive the cue through AudiobookPlayer's mini bar: that widget already
+    -- owns bottom-screen taps. A separate BottomContainer overlay looked
+    -- tappable but never received gestures (player sat above / ate events).
+    local bar = self.media_sync and self.media_sync.playback_bar
+    if not bar or not bar.setReturnHint then return end
+    pcall(function() bar:setReturnHint(true) end)
+end
+
+function Audiobook:_hideReturnToReadAloudButton()
+    local bar = self.media_sync and self.media_sync.playback_bar
+    if bar and bar.setReturnHint then
+        pcall(function() bar:setReturnHint(false) end)
+    end
+    -- Clean up any leftover overlay from older builds.
+    if self._return_to_readaloud_widget then
+        pcall(function()
+            UIManager:close(self._return_to_readaloud_widget)
+        end)
+        self._return_to_readaloud_widget = nil
+    end
+end
+
 function Audiobook:_handlePageTurnFollow()
     if not self._init_ok then return end
-    if not self:getSetting("media_follow_page_turn", true) then return end
     if not self.media_sync then return end
     if not self.media_sync.overlay_mode then return end
     if self.media_sync.state ~= self.media_sync.STATE.PLAYING
        and self.media_sync.state ~= self.media_sync.STATE.PAUSED then
+        self:_hideReturnToReadAloudButton()
         return
     end
     -- Ignore page events caused by MediaSync's own auto-follow.
@@ -2950,18 +3124,41 @@ function Audiobook:_handlePageTurnFollow()
         if self._page_turn_follow_deadline and now < self._page_turn_follow_deadline then
             return
         end
-        self._page_turn_follow_deadline = now + Time.s(1.0)
+        self._page_turn_follow_deadline = now + Time.s(0.8)
     end
 
     self._in_handle_page_turn_follow = true
     local ok, err = pcall(function()
+        local on_audio_page = self:_currentAudioSentenceVisible()
+
+        if self.media_sync.state == self.media_sync.STATE.PAUSED then
+            -- Browsing while paused: drop the stale highlight (it would
+            -- otherwise be redrawn at the wrong place on the new page) and
+            -- offer a Readest-style return button.
+            pcall(function() self.media_sync:clearSentenceHighlight() end)
+            if on_audio_page then
+                self:_hideReturnToReadAloudButton()
+            else
+                self:_showReturnToReadAloudButton()
+            end
+            return
+        end
+
+        -- PLAYING
+        if not on_audio_page then
+            pcall(function() self.media_sync:clearSentenceHighlight() end)
+            self:_showReturnToReadAloudButton()
+        else
+            self:_hideReturnToReadAloudButton()
+        end
+
+        if not self:getSetting("media_follow_page_turn", true) then return end
+
         local start_entry = self:_findCurrentPageSmilEntry()
         if not start_entry or not start_entry.audio_path then return end
 
         -- If the current audio position is already inside the current page's
-        -- narration range, do not seek.  This prevents auto-follow or a
-        -- resume-navigation from jumping back to the first sentence of the
-        -- page we just moved to.
+        -- narration range, do not seek.
         local current_path = self.media_sync.media_engine and self.media_sync.media_engine.current_path
         local current_pos = self.media_sync.media_engine and self.media_sync.media_engine:getPosition()
         if current_path == start_entry.audio_path and current_pos then
@@ -2978,22 +3175,17 @@ function Audiobook:_handlePageTurnFollow()
             end
         end
 
-        -- Suppress MediaSync's own auto page-follow for a short grace period so
-        -- the seek/restart below doesn't immediately trigger another page turn.
         if Time then
             self._suppress_media_sync_auto_page_follow = Time.now() + Time.s(3.0)
         end
 
-        -- Only seek if we are changing to a different audio file or a later time.
         if current_path and current_path ~= start_entry.audio_path then
             self.media_sync:stop()
             self:_startSmilPlayback(self.ui.document.file_path or self.ui.document.file, start_entry, false)
         else
             self.media_sync:seekToTime(start_entry.start_time)
-            if self.media_sync.state == self.media_sync.STATE.PAUSED then
-                self.media_sync:resume()
-            end
         end
+        self:_hideReturnToReadAloudButton()
     end)
     self._in_handle_page_turn_follow = false
     if not ok then

--- a/main.lua
+++ b/main.lua
@@ -816,7 +816,7 @@ function Audiobook:addToMainMenu(menu_items)
                         callback = function()
                             self:toggleSetting("keep_reader_status_bars", false)
                         end,
-                        help_text = _("When enabled, the minimized read-aloud mini player sits above KOReader’s bottom status bar (and does not cover it). The CRE alt status bar at the top is left alone. When disabled (default), the mini player sits at the very bottom of the screen."),
+                        help_text = _("When enabled, the minimized read-aloud mini player sits above KOReader’s bottom status bar / progress bar (alt status bar at the top is unchanged). The page always reflows so book text ends above the mini player — the player never covers readable text. When disabled (default), the mini player sits at the bottom of the screen (may cover the status bar) but text is still reflowed above it."),
                     },
                     {
                         text = _("Sleep timer"),

--- a/main.lua
+++ b/main.lua
@@ -1487,6 +1487,28 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
 
     -- Reuse a just-loaded cache (e.g. "Play aligned from here") so we don't
     -- re-parse the whole EPUB and invalidate start_entry.audio_path keys.
+    -- Drop the in-memory cache when the EPUB was replaced in-place (Storyteller
+    -- re-export keeps the same path but changes size/mtime).
+    local function epub_fp(path)
+        local ok, lfs = pcall(require, "libs/libkoreader-lfs")
+        if ok and lfs and lfs.attributes then
+            local attr = lfs.attributes(path)
+            if attr and attr.size and attr.modification then
+                return string.format("%d:%d", attr.size, attr.modification)
+            end
+        end
+        return nil
+    end
+    local cur_fp = epub_fp(doc_path)
+    if self._smil_doc_path == doc_path and cur_fp and self._smil_epub_fp
+        and self._smil_epub_fp ~= cur_fp then
+        logger.warn("Audiobook: EPUB replaced on disk — clearing SMIL memory cache")
+        self._smil_parser = nil
+        self._smil_timing_data = nil
+        self._smil_by_file = nil
+        self._smil_page_index = nil
+    end
+
     local parser = self._smil_parser
     local timing_data = self._smil_timing_data
     if not (parser and timing_data and self._smil_doc_path == doc_path) then
@@ -1670,6 +1692,7 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
         self._smil_by_file = by_file
         self._smil_page_index = nil
         self._smil_doc_path = doc_path
+        self._smil_epub_fp = cur_fp or epub_fp(doc_path)
         local first = start_file or files[1]
         -- Guard against a saved resume audio_path that no longer matches the
         -- parsed timing data (e.g., path normalization differences).

--- a/main.lua
+++ b/main.lua
@@ -2557,10 +2557,18 @@ function Audiobook:_startSmilPlaybackFromSelection(doc_path, selected_text, allo
 
     local parser = self._smil_parser
     local timing_data = self._smil_timing_data
-    if parser and timing_data and self._smil_doc_path ~= doc_path then
-        -- Cached data belongs to a different book; discard it.
-        logger.warn("Audiobook: SMIL cache is for", self._smil_doc_path,
-            "but current doc is", doc_path, "; reloading")
+    local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+    local cur_fp
+    if ok_lfs and lfs and lfs.attributes then
+        local attr = lfs.attributes(doc_path)
+        if attr and attr.size and attr.modification then
+            cur_fp = string.format("%d:%d", attr.size, attr.modification)
+        end
+    end
+    if parser and timing_data and (self._smil_doc_path ~= doc_path
+        or (cur_fp and self._smil_epub_fp and self._smil_epub_fp ~= cur_fp)) then
+        -- Cached data belongs to a different book or a replaced EPUB.
+        logger.warn("Audiobook: SMIL cache stale for", doc_path, "; reloading")
         parser = nil
         timing_data = nil
         self._smil_parser = nil
@@ -2605,6 +2613,7 @@ function Audiobook:_startSmilPlaybackFromSelection(doc_path, selected_text, allo
         self._smil_timing_data = timing_data
         self._smil_page_index = nil
         self._smil_doc_path = doc_path
+        self._smil_epub_fp = cur_fp
     end
 
     local start_entry = self:_matchSmilEntryFromSelection(selected_text, timing_data, parser)

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -200,21 +200,28 @@ function MediaSync:_gotoSmilFragment(text_doc, fragment_id, allow_scan, sentence
         return false
     end
 
-    -- 3. Fast cross-document probe: crengine can often resolve a plain id to
-    -- a global page number even when the fragment is not in the currently
-    -- loaded content document.  If it returns a valid page, load it and verify
-    -- the fragment is reachable before scrolling.
+    -- 3. Spine DocFragment jump (reliable for Storyteller EPUBs): use the EPUB
+    -- spine order to know which DocFragment contains the target document.
+    if self:_gotoViaSpineDocFragment(text_doc, fragment_id, start_page) then
+        cache_current_xpointer()
+        if fragment_in_document() then scroll_to_fragment() end
+        UIManager:setDirty("all", "ui")
+        return true
+    end
+
+    -- 4. getPageFromXPointer probe (skip page 1 — bogus on Kindle).
     local ok_fp, page_fp = pcall(function()
         return ui.document:getPageFromXPointer(xp)
     end)
-    if ok_fp and page_fp and page_fp > 0 and page_fp ~= start_page then
+    if ok_fp and page_fp and page_fp > 1 and page_fp ~= start_page then
         logger.warn("MediaSync: getPageFromXPointer page", page_fp, "for", xp)
         if try_page(page_fp) then
             return true
         end
+        pcall(function() ui.document:gotoPage(start_page, false) end)
     end
 
-    -- 4. TOC fallback: match the content document's chapter title against the
+    -- 5. TOC fallback: match the content document's chapter title against the
     -- EPUB table of contents, derive the DocFragment index from the TOC
     -- xpointer, and jump to the fragment with a full internal xpointer.
     if allow_scan then
@@ -226,19 +233,7 @@ function MediaSync:_gotoSmilFragment(text_doc, fragment_id, allow_scan, sentence
         end
     end
 
-    -- 4b. Spine DocFragment fallback: use the EPUB spine order to know which
-    -- DocFragment contains the target content document, then build a full
-    -- xpointer to the fragment.
-    if allow_scan then
-        if self:_gotoViaSpineDocFragment(text_doc, fragment_id, start_page) then
-            cache_current_xpointer()
-            if fragment_in_document() then scroll_to_fragment() end
-            UIManager:setDirty("all", "ui")
-            return true
-        end
-    end
-
-    -- 5. Text-search fallback: search the whole rendered book for the sentence
+    -- 6. Text-search fallback: search the whole rendered book for the sentence
     -- text.  crengine cannot resolve a plain fragment id to a global page on
     -- this device, but findText returns full internal xpointers that usually
     -- can be followed.  We accept an occurrence whose DocFragment index matches
@@ -304,12 +299,12 @@ function MediaSync:_gotoSmilFragment(text_doc, fragment_id, allow_scan, sentence
                         logger.warn("MediaSync: text-search onGotoXPointer",
                             "ok=", tostring(ok_goto),
                             "page_before=", before_page, "page_after=", after_page)
-                        if ok_goto and after_page and after_page ~= before_page then
-                            cache_current_xpointer()
-                            if fragment_in_document() then scroll_to_fragment() end
-                            UIManager:setDirty("all", "ui")
-                            return true
-                        end
+                        if ok_goto and after_page then
+                cache_current_xpointer()
+                if fragment_in_document() then scroll_to_fragment() end
+                UIManager:setDirty("all", "ui")
+                return true
+            end
                     end
                 end
             end
@@ -458,8 +453,13 @@ function MediaSync:_tryGotoDocFragment(text_doc, fragment_id, docfrag_n, start_p
             logger.warn("MediaSync: onGotoXPointer full xp",
                 "ok=", tostring(ok_goto),
                 "page_before=", before_page, "page_after=", after_page)
-            if ok_goto and after_page and after_page ~= before_page then
-                return true, norm
+            if ok_goto and after_page then
+                if fragment_in_document() then
+                    return true, norm
+                end
+                if after_page ~= before_page then
+                    return true, norm
+                end
             end
         end
     end
@@ -1136,18 +1136,41 @@ function MediaSync:_updateHighlightAtTime(pos)
                 and follow_page_turns and not suppress_auto_follow then
                 local ui = self.plugin and self.plugin.ui
                 if ui then
-                    pcall(function()
-                        self:_markPageFollowAuto()
-                        local ms = self
-                        ui:handleEvent(Event:new("GotoViewRel", 1))
-                        self.highlight_manager:highlightSentence(sent_obj, {sentences = {sent_obj}})
-                        if sentence.fragment_id then
-                            self:_cacheResolvedXPointer(sentence.text_doc, sentence.fragment_id)
-                        end
-                        UIManager:scheduleIn(2.5, function()
-                            ms:_clearPageFollowAuto()
+                    local expected_n = self:_getExpectedDocFragmentIndex(sentence.text_doc)
+                    local cur_frag = nil
+                    if ui.document then
+                        local cur_xp = ui.document:getXPointer()
+                        cur_frag = cur_xp and tonumber(cur_xp:match("DocFragment%[(%d+)%]"))
+                    end
+                    local cross_doc = expected_n and cur_frag and expected_n ~= cur_frag
+                    if cross_doc and sentence.fragment_id then
+                        pcall(function()
+                            self:_markPageFollowAuto()
+                            local ms = self
+                            self:_gotoSmilFragment(sentence.text_doc, sentence.fragment_id, true, sentence.text)
+                            UIManager:scheduleIn(0.3, function()
+                                pcall(function()
+                                    self.highlight_manager:highlightSentence(sent_obj, {sentences = {sent_obj}})
+                                end)
+                            end)
+                            UIManager:scheduleIn(2.5, function()
+                                ms:_clearPageFollowAuto()
+                            end)
                         end)
-                    end)
+                    elseif not cross_doc then
+                        pcall(function()
+                            self:_markPageFollowAuto()
+                            local ms = self
+                            ui:handleEvent(Event:new("GotoViewRel", 1))
+                            self.highlight_manager:highlightSentence(sent_obj, {sentences = {sent_obj}})
+                            if sentence.fragment_id then
+                                self:_cacheResolvedXPointer(sentence.text_doc, sentence.fragment_id)
+                            end
+                            UIManager:scheduleIn(2.5, function()
+                                ms:_clearPageFollowAuto()
+                            end)
+                        end)
+                    end
                 end
             end
             -- If the sentence is genuinely not on the visible page and we
@@ -1693,6 +1716,11 @@ function MediaSync:_showModalMenu(opts)
 end
 
 function MediaSync:showChapterList()
+    if self.overlay_mode and self.plugin and self.plugin._smil_overlay_chapters
+        and #self.plugin._smil_overlay_chapters > 0 then
+        self:showOverlayChapterList()
+        return
+    end
     if self.playlist_files and #self.playlist_files > 0 then
         self:showPlaylist()
         return
@@ -1718,6 +1746,61 @@ function MediaSync:showChapterList()
         })
     end
     self:_showModalMenu{ title = _("Chapters"), items = items, current = current_idx }
+end
+
+--- Storyteller read-along: list every SMIL content-document chapter, not just
+--- the four embedded MP4 audio segments shown in the playlist menu.
+function MediaSync:showOverlayChapterList()
+    local chapters = self.plugin and self.plugin._smil_overlay_chapters
+    if not chapters or #chapters == 0 then
+        UIManager:show(InfoMessage:new{
+            text = _("No chapters available."),
+            timeout = 2,
+        })
+        return
+    end
+
+    local current_time = self.media_engine and self.media_engine:getPosition() or 0
+    local current_path = self.media_engine and self.media_engine.current_path
+    local current_idx = 1
+    for i, ch in ipairs(chapters) do
+        if ch.audio_path == current_path and ch.start_time <= current_time + 1 then
+            current_idx = i
+        end
+    end
+
+    local items = {}
+    for i, ch in ipairs(chapters) do
+        table.insert(items, {
+            text = (ch.title or _("Chapter") .. " " .. i)
+                .. "  (" .. self:_formatTime(ch.start_time) .. ")",
+            callback = function()
+                self:_closeModalMenu()
+                self:seekToOverlayChapter(i)
+            end,
+        })
+    end
+    self:_showModalMenu{ title = _("Chapters"), items = items, current = current_idx }
+end
+
+function MediaSync:seekToOverlayChapter(index)
+    local chapters = self.plugin and self.plugin._smil_overlay_chapters
+    if not chapters or not chapters[index] then return end
+    local ch = chapters[index]
+    if ch.audio_path and self.media_engine
+        and self.media_engine.current_path ~= ch.audio_path then
+        if self.plugin and self.plugin._playAudioFile then
+            self.plugin:_playAudioFile(ch.audio_path, self.playlist_files)
+        end
+    end
+    UIManager:scheduleIn(0.2, function()
+        self:seekToTime(ch.start_time)
+        if self.overlay_mode and ch.fragment_id then
+            UIManager:scheduleIn(0.3, function()
+                self:navigateToSentenceAtTime(ch.start_time)
+            end)
+        end
+    end)
 end
 
 function MediaSync:showPlaylist()

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -6,6 +6,7 @@ Mirrors SyncController patterns but without TTS synthesis or sentence prefetch.
 @module koplugin.audiobook.mediasync
 --]]
 
+local Device = require("device")
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
@@ -591,7 +592,10 @@ end
 
 function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist_files, original_path, start_position)
     if self.state == self.STATE.PLAYING or self.state == self.STATE.PAUSED then
-        self:stop(true) -- keep chapter menu open during track transitions
+        -- Soft stop: keep A2DP keepalive + player UI across playlist file changes.
+        -- A hard stop was killing track-advance keepalive and hiding the bar,
+        -- which left AirPods silent and the play button dead (STOPPED).
+        self:stop(true, { track_transition = true })
     end
 
     if not audio_path or not timing_data or #timing_data == 0 then
@@ -599,6 +603,7 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
         return false
     end
 
+    self._track_advance_pending = nil
     self.state = self.STATE.LOADING
     self.timing_data = timing_data
     self.chapters = chapters or {}
@@ -730,7 +735,11 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
     return true
 end
 
-function MediaSync:stop(keep_chapter_menu)
+--- @param keep_chapter_menu boolean|nil
+--- @param opts table|nil  { track_transition = true } spares A2DP keepalive and player UI
+function MediaSync:stop(keep_chapter_menu, opts)
+    opts = opts or {}
+    local track_transition = opts.track_transition and true or false
     local was_playing = self.state ~= self.STATE.STOPPED
     self.state = self.STATE.STOPPED
     self._chain_generation = self._chain_generation + 1
@@ -745,16 +754,23 @@ function MediaSync:stop(keep_chapter_menu)
     end
 
     if self.media_engine then
-        pcall(function() self.media_engine:stop() end)
+        pcall(function()
+            -- Hard stop (user close / end of book): tear down keepalive too.
+            -- Track transition: spare keepalive so AirPods A2DP stays armed.
+            self.media_engine._kill_keepalive_on_stop = not track_transition
+            self.media_engine:stop()
+        end)
     end
     if self.highlight_manager then
         pcall(function() self.highlight_manager:clearHighlights() end)
     end
-    if self.playback_bar then
-        pcall(function() self.playback_bar:hide() end)
-    end
-    if self.plugin and self.plugin._hideReturnToReadAloudButton then
-        pcall(function() self.plugin:_hideReturnToReadAloudButton() end)
+    if not track_transition then
+        if self.playback_bar then
+            pcall(function() self.playback_bar:hide() end)
+        end
+        if self.plugin and self.plugin._hideReturnToReadAloudButton then
+            pcall(function() self.plugin:_hideReturnToReadAloudButton() end)
+        end
     end
     if not keep_chapter_menu then
         if self._chapter_menu_window then
@@ -767,7 +783,7 @@ function MediaSync:stop(keep_chapter_menu)
     end
 
     if was_playing then
-        logger.warn("MediaSync: stopped")
+        logger.warn("MediaSync: stopped", track_transition and "(track transition)" or "")
     end
 end
 
@@ -909,7 +925,30 @@ function MediaSync:prevSentence()
     self:seekToTime(self.timing_data[idx].start_time)
 end
 
+--- Index of the current Storyteller SMIL content-document chapter (not audio part).
+function MediaSync:_currentOverlayChapterIndex()
+    local chapters = self.plugin and self.plugin._smil_overlay_chapters
+    if not chapters or #chapters == 0 then return nil, nil end
+    local current_time = self.media_engine and self.media_engine:getPosition() or 0
+    local current_path = self.media_engine and self.media_engine.current_path
+    local current_idx = 1
+    for i, ch in ipairs(chapters) do
+        if ch.audio_path == current_path and (ch.start_time or 0) <= current_time + 1 then
+            current_idx = i
+        end
+    end
+    return current_idx, chapters
+end
+
 function MediaSync:nextChapter()
+    -- Storyteller read-along: ⏭ means next SMIL chapter, not next ~4 min audio part.
+    if self.overlay_mode then
+        local idx, chapters = self:_currentOverlayChapterIndex()
+        if chapters and idx and idx < #chapters then
+            self:seekToOverlayChapter(idx + 1)
+        end
+        return
+    end
     if self.playlist_files and #self.playlist_files > 0 then
         local idx = (self.current_playlist_idx or 1) + 1
         if idx <= #self.playlist_files then
@@ -928,6 +967,13 @@ function MediaSync:nextChapter()
 end
 
 function MediaSync:prevChapter()
+    if self.overlay_mode then
+        local idx, chapters = self:_currentOverlayChapterIndex()
+        if chapters and idx and idx > 1 then
+            self:seekToOverlayChapter(idx - 1)
+        end
+        return
+    end
     if self.playlist_files and #self.playlist_files > 0 then
         local idx = (self.current_playlist_idx or 1) - 1
         if idx >= 1 then
@@ -945,13 +991,36 @@ function MediaSync:prevChapter()
     end
 end
 
+--- Keepalive (+ optional BT Disconnect/Connect) before switching audio files.
+--- @param then_fn function  called after the bridge (or immediately off-Kindle)
+function MediaSync:_bridgeKindleA2dpForTrackChange(then_fn)
+    local me = self.media_engine
+    local cycle_bt = false
+    if self.plugin and self.plugin.getSetting then
+        cycle_bt = self.plugin:getSetting("kindle_bt_reconnect_on_track", false) and true or false
+    end
+    if me and me.prepareKindleTrackAdvance then
+        me:prepareKindleTrackAdvance(function(_ok)
+            if then_fn then then_fn() end
+        end, { cycle_bt = cycle_bt })
+        return
+    end
+    if me and me._startKindleA2dpKeepalive then
+        pcall(function() me:_startKindleA2dpKeepalive("track-advance") end)
+    end
+    if then_fn then then_fn() end
+end
+
 function MediaSync:switchToPlaylistFile(index)
     if not self.playlist_files or not self.playlist_files[index] then return end
     self.current_playlist_idx = index
     local file_path = self.playlist_files[index].path
-    if self.plugin and self.plugin._playAudioFile then
-        self.plugin:_playAudioFile(file_path, self.playlist_files)
-    end
+    -- Manual ⏭/⏮ and playlist picks: same BT reconnect as natural EOS advance.
+    self:_bridgeKindleA2dpForTrackChange(function()
+        if self.plugin and self.plugin._playAudioFile then
+            self.plugin:_playAudioFile(file_path, self.playlist_files)
+        end
+    end)
 end
 
 function MediaSync:toggleLoop()
@@ -1092,17 +1161,15 @@ function MediaSync:_updateHighlightAtTime(pos)
         -- The SMIL fragment id resolves as a "#id" xpointer in crengine;
         -- turn the page before highlighting so the text-matching
         -- highlighter can find the sentence on the visible page.
-        -- This auto-follow is gated by the same setting as manual
-        -- page-turn seeking so users who disable page-follow stay in
-        -- control of the page.
+        -- Auto page-follow while the user stays with the narration.
+        -- Manual browsing away (_readaloud_browsing_away) must not yank the
+        -- page back or restart audio — only pause highlighting.
         local follow_page_turns = true
         if self.plugin and self.plugin.getSetting then
             follow_page_turns = self.plugin:getSetting("media_follow_page_turn", true)
         end
-        -- After a manual page turn the plugin seeks/restarts playback at the
-        -- new page. Suppress MediaSync's own auto-follow briefly so that seek
-        -- does not immediately trigger another page turn.
-        local suppress_auto_follow = false
+        local browsing_away = self.plugin and self.plugin._readaloud_browsing_away
+        local suppress_auto_follow = browsing_away and true or false
         if self.plugin and self.plugin._suppress_media_sync_auto_page_follow and time then
             if time.now() < self.plugin._suppress_media_sync_auto_page_follow then
                 suppress_auto_follow = true
@@ -1126,10 +1193,22 @@ function MediaSync:_updateHighlightAtTime(pos)
             if hl_ok and sentence.fragment_id then
                 self:_cacheResolvedXPointer(sentence.text_doc, sentence.fragment_id)
             end
+            -- Narration caught up to the page the user was browsing.
+            if hl_ok and browsing_away and self.plugin then
+                self.plugin._readaloud_browsing_away = false
+                browsing_away = false
+                if self.plugin._hideReturnToReadAloudButton then
+                    pcall(function() self.plugin:_hideReturnToReadAloudButton() end)
+                end
+            elseif browsing_away and not hl_ok then
+                -- Stay off-page: drop the failed highlight attempt immediately.
+                pcall(function() self.highlight_manager:clearHighlights() end)
+            end
 
             -- If the sentence is not on the visible page, JUMP to its fragment
             -- (spine/TOC/findText).  Never crawl with GotoViewRel on every
             -- sentence — that freezes Kindle touch input for minutes.
+            -- Skip while the user has manually browsed away.
             local jump_pending = false
             if not hl_ok and self.overlay_mode and sentence.fragment_id
                 and follow_page_turns and not suppress_auto_follow then
@@ -1378,13 +1457,34 @@ end
 
 function MediaSync:_onPlaybackComplete(gen)
     if self._chain_generation ~= gen then return end
+    if self._track_advance_pending then
+        logger.warn("MediaSync: playback complete ignored (track advance already pending)")
+        return
+    end
     logger.warn("MediaSync: playback complete")
     -- In playlist mode, auto-advance to the next track
     if self.playlist_files and #self.playlist_files > 0 then
         local next_idx = (self.current_playlist_idx or 1) + 1
+        local function advance(idx)
+            -- Freeze sync loops for the BT-cycle window (~5–10 s) so we do not
+            -- re-enter complete → double-advance.
+            self._track_advance_pending = true
+            self._chain_generation = self._chain_generation + 1
+            if self._sync_timer then
+                UIManager:unschedule(self._sync_timer)
+                self._sync_timer = nil
+            end
+            if self._position_timer then
+                UIManager:unschedule(self._position_timer)
+                self._position_timer = nil
+            end
+            -- Natural EOS: keepalive + forced BT reconnect, then next file.
+            logger.warn("MediaSync: auto-advancing to playlist track", idx,
+                "(A2DP bridge + BT cycle)")
+            self:switchToPlaylistFile(idx)
+        end
         if next_idx <= #self.playlist_files then
-            logger.warn("MediaSync: auto-advancing to playlist track", next_idx)
-            self:switchToPlaylistFile(next_idx)
+            advance(next_idx)
             return
         elseif self.loop_enabled then
             -- Loop: wrap back to start (or random if shuffled)
@@ -1395,7 +1495,7 @@ function MediaSync:_onPlaybackComplete(gen)
                 next_idx = 1
             end
             logger.warn("MediaSync: looping to playlist track", next_idx)
-            self:switchToPlaylistFile(next_idx)
+            advance(next_idx)
             return
         end
     end
@@ -1422,7 +1522,21 @@ function MediaSync:showPlaybackBar()
     end
     -- For standalone audio (scrubber mode), use full-screen AudiobookPlayer overlay
     local AudiobookPlayer = dofile(PLUGIN_PATH .. "audiobookplayer.lua")
-    local title = self.timing_data and self.timing_data[1] and self.timing_data[1].text or _("Audiobook")
+    -- Top-bar title = book name (NOT the first SMIL sentence text — that looked
+    -- like random words next to the BT button).
+    local title = _("Audiobook")
+    local ui = self.plugin and self.plugin.ui
+    if ui and ui.document then
+        local ok_props, props = pcall(function() return ui.document:getProps() end)
+        if ok_props and props and props.title and props.title ~= "" then
+            title = props.title
+        end
+    end
+    if title == _("Audiobook") and self.plugin and self.plugin._smil_doc_path then
+        title = self.plugin._smil_doc_path:match("([^/]+)%.[^./]+$")
+            or self.plugin._smil_doc_path:match("([^/]+)$")
+            or title
+    end
     -- Derive output name: use original playlist filename when available
     local output_name = ""
     if self.playlist_files and self.current_playlist_idx then
@@ -1458,6 +1572,26 @@ function MediaSync:showPlaybackBar()
                 self:pause()
             elseif self.state == self.STATE.PAUSED then
                 self:resume()
+            elseif self.media_engine and self.media_engine.current_path then
+                -- After a hard stop / botched track advance the bar can stay
+                -- visible while state is STOPPED — play must restart audio.
+                logger.warn("MediaSync: play from STOPPED — restarting current file")
+                local gen = self._chain_generation + 1
+                self._chain_generation = gen
+                self.state = self.STATE.PLAYING
+                local ok = self.media_engine:play(
+                    function() self:_onPlaybackComplete(gen) end,
+                    function(err) self:_onPlaybackFail(gen, err) end
+                )
+                if ok then
+                    self:_startSyncLoop(gen)
+                    self:_startPositionPoller(gen)
+                    if self.playback_bar and self.playback_bar.setPlaying then
+                        pcall(function() self.playback_bar:setPlaying(true) end)
+                    end
+                else
+                    self.state = self.STATE.STOPPED
+                end
             end
         end,
         on_skip_back = function()
@@ -1518,11 +1652,21 @@ function MediaSync:showPlaybackBar()
             end
         end,
         on_refocus = self.overlay_mode and function()
+            if self.plugin then
+                self.plugin._readaloud_browsing_away = false
+            end
             self:refocusToCurrentSentence()
             if self.plugin and self.plugin._hideReturnToReadAloudButton then
                 pcall(function() self.plugin:_hideReturnToReadAloudButton() end)
             end
         end or nil,
+        -- BT reconnect lives in plugin settings (Reconnect BT on track change)
+        -- and the Bluetooth menu — no overlay "BT" button.
+        show_fix_audio = false,
+        keep_reader_status_bars = self.plugin
+            and self.plugin.getSetting
+            and self.plugin:getSetting("keep_reader_status_bars", false)
+            or false,
     }
     player:show()
     if self.plugin then
@@ -1846,20 +1990,28 @@ function MediaSync:seekToOverlayChapter(index)
     local chapters = self.plugin and self.plugin._smil_overlay_chapters
     if not chapters or not chapters[index] then return end
     local ch = chapters[index]
+    local function after_audio_ready()
+        UIManager:scheduleIn(0.2, function()
+            self:seekToTime(ch.start_time)
+            if self.overlay_mode and ch.fragment_id then
+                UIManager:scheduleIn(0.3, function()
+                    self:navigateToSentenceAtTime(ch.start_time)
+                end)
+            end
+        end)
+    end
     if ch.audio_path and self.media_engine
         and self.media_engine.current_path ~= ch.audio_path then
-        if self.plugin and self.plugin._playAudioFile then
-            self.plugin:_playAudioFile(ch.audio_path, self.playlist_files)
-        end
+        -- Cross-file chapter jump: BT reconnect then load the new audio part.
+        self:_bridgeKindleA2dpForTrackChange(function()
+            if self.plugin and self.plugin._playAudioFile then
+                self.plugin:_playAudioFile(ch.audio_path, self.playlist_files)
+            end
+            after_audio_ready()
+        end)
+        return
     end
-    UIManager:scheduleIn(0.2, function()
-        self:seekToTime(ch.start_time)
-        if self.overlay_mode and ch.fragment_id then
-            UIManager:scheduleIn(0.3, function()
-                self:navigateToSentenceAtTime(ch.start_time)
-            end)
-        end
-    end)
+    after_audio_ready()
 end
 
 function MediaSync:showPlaylist()

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -705,6 +705,8 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
 
     -- Show playback bar in scrubber mode
     self:showPlaybackBar()
+    -- Reflow page so book text ends above the mini player (never covered).
+    self:_reserveMiniBarSpace()
 
     -- Resume from saved position on initial start, if any.
     if self._start_position and self._start_position > 0 then
@@ -771,6 +773,8 @@ function MediaSync:stop(keep_chapter_menu, opts)
         if self.plugin and self.plugin._hideReturnToReadAloudButton then
             pcall(function() self.plugin:_hideReturnToReadAloudButton() end)
         end
+        -- Restore page margins only on hard stop (keep reservation across tracks).
+        self:_releaseMiniBarSpace()
     end
     if not keep_chapter_menu then
         if self._chapter_menu_window then
@@ -784,6 +788,76 @@ function MediaSync:stop(keep_chapter_menu, opts)
 
     if was_playing then
         logger.warn("MediaSync: stopped", track_transition and "(track transition)" or "")
+    end
+end
+
+--- Footer height (status bar + progress) for positioning / margin math.
+function MediaSync:_readerFooterHeight()
+    local ui = self.plugin and self.plugin.ui
+    local view = ui and ui.view
+    if not view or not view.footer or not view.footer_visible then return 0 end
+    local ok, h = pcall(function() return view.footer:getHeight() end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    ok, h = pcall(function()
+        local d = view.footer.dimen
+        return d and d.h or 0
+    end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    return 0
+end
+
+--[[--
+Reserve the mini player's height in the document bottom margin so book text
+reflows above it (same approach as SyncController:_reserveBarSpace for TTS).
+Never leave the mini bar covering readable text — including when the user
+keeps KOReader's status / progress bars visible under the mini player.
+--]]
+function MediaSync:_reserveMiniBarSpace()
+    if self._bar_space_reserved then return end
+    -- Full-screen (non-overlay) player intentionally covers the book.
+    if not self.overlay_mode then return end
+    if not (self.plugin and self.plugin.ui and self.plugin.ui.rolling) then return end
+    local ui = self.plugin.ui
+    local tp = ui.typeset
+    if not (tp and tp.unscaled_margins and ui.document and ui.document.setPageMargins) then
+        return
+    end
+    local bar = self.playback_bar
+    local bar_h = bar and (bar._mini_height or (bar.dimen and bar.dimen.h)) or 0
+    if not bar_h or bar_h <= 0 then
+        bar_h = Screen:scaleBySize(44)
+    end
+    local m = tp.unscaled_margins
+    -- Bottom inset from screen edge so CRE text ends above the mini player.
+    -- With "Keep status bars": also clear the footer/progress stack under the mini bar.
+    -- Without it: mini bar sits on the bottom edge (may cover the footer); text clears the bar only.
+    local bottom = Screen:scaleBySize(m[4]) + bar_h
+    local keep_bars = self.plugin and self.plugin.getSetting
+        and self.plugin:getSetting("keep_reader_status_bars", false)
+    if keep_bars then
+        bottom = bottom + self:_readerFooterHeight()
+    end
+    local ok = pcall(ui.document.setPageMargins, ui.document,
+        Screen:scaleBySize(m[1]), Screen:scaleBySize(m[2]),
+        Screen:scaleBySize(m[3]), bottom)
+    if ok then
+        self._bar_space_reserved = true
+        self._reserved_mini_bar_h = bar_h
+        ui:handleEvent(Event:new("UpdatePos"))
+        logger.warn("MediaSync: reserved", bar_h, "px bottom margin for mini player")
+    end
+end
+
+function MediaSync:_releaseMiniBarSpace()
+    if not self._bar_space_reserved then return end
+    self._bar_space_reserved = false
+    self._reserved_mini_bar_h = nil
+    if not (self.plugin and self.plugin.ui) then return end
+    local ui = self.plugin.ui
+    local tp = ui.typeset
+    if tp and tp.unscaled_margins then
+        ui:handleEvent(Event:new("SetPageMargins", tp.unscaled_margins))
+        logger.warn("MediaSync: restored user page margins after mini player")
     end
 end
 
@@ -1518,6 +1592,7 @@ end
 
 function MediaSync:showPlaybackBar()
     if self.playback_bar and self.playback_bar:isVisible() then
+        self:_reserveMiniBarSpace()
         return
     end
     -- For standalone audio (scrubber mode), use full-screen AudiobookPlayer overlay
@@ -1676,6 +1751,7 @@ function MediaSync:showPlaybackBar()
         end)
     end
     self.playback_bar = player
+    self:_reserveMiniBarSpace()
 end
 
 function MediaSync:navigateToSentenceEntry(entry)

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -999,19 +999,68 @@ function MediaSync:prevSentence()
     self:seekToTime(self.timing_data[idx].start_time)
 end
 
---- Index of the current Storyteller SMIL content-document chapter (not audio part).
-function MediaSync:_currentOverlayChapterIndex()
+--- Resolve the current Storyteller SMIL content-document chapter (not ~4 min audio part).
+-- Chapters are keyed by (audio_path, start_time within that file). Across playlist
+-- advances we must compare playlist order, not only the current file's local clock.
+function MediaSync:_resolveOverlayChapter()
     local chapters = self.plugin and self.plugin._smil_overlay_chapters
     if not chapters or #chapters == 0 then return nil, nil end
     local current_time = self.media_engine and self.media_engine:getPosition() or 0
     local current_path = self.media_engine and self.media_engine.current_path
+    local path_order = {}
+    if self.playlist_files then
+        for i, f in ipairs(self.playlist_files) do
+            if f.path then path_order[f.path] = i end
+        end
+    end
+    local cur_order = (current_path and path_order[current_path])
+        or self.current_playlist_idx
+        or 1
     local current_idx = 1
     for i, ch in ipairs(chapters) do
-        if ch.audio_path == current_path and (ch.start_time or 0) <= current_time + 1 then
+        local ch_order = (ch.audio_path and path_order[ch.audio_path]) or 0
+        local st = ch.start_time or 0
+        if ch_order < cur_order
+            or (ch.audio_path == current_path and st <= current_time + 1) then
             current_idx = i
         end
     end
-    return current_idx, chapters
+    return chapters[current_idx], current_idx
+end
+
+--- Index of the current Storyteller SMIL content-document chapter (not audio part).
+function MediaSync:_currentOverlayChapterIndex()
+    local ch, idx = self:_resolveOverlayChapter()
+    local chapters = self.plugin and self.plugin._smil_overlay_chapters
+    if not ch then return nil, chapters end
+    return idx, chapters
+end
+
+--- Push the live chapter title into the player (full + mini bar).
+function MediaSync:_refreshPlaybackBarTitles()
+    if not self.playback_bar then return end
+    local ch = self:getCurrentChapter()
+    local label = ch and ch.title or nil
+    if (not label or label == "") and self.playlist_files and self.current_playlist_idx then
+        local f = self.playlist_files[self.current_playlist_idx]
+        label = f and f.name or nil
+    end
+    if not label or label == "" then return end
+    pcall(function()
+        -- Force mini refresh even when the chapter label is unchanged (e.g. first
+        -- paint used the book title before chapter_title was applied).
+        local bar = self.playback_bar
+        if bar.chapter_title == label and bar._mini_title then
+            bar:_updateMiniWidgets()
+        end
+        bar:updateChapterTitle(label)
+        if ch and bar.setCurrentChapter then
+            bar:setCurrentChapter(ch)
+        end
+        if not self.overlay_mode and bar.updateOutputName then
+            bar:updateOutputName(label)
+        end
+    end)
 end
 
 function MediaSync:nextChapter()
@@ -1498,13 +1547,10 @@ function MediaSync:_startPositionPoller(gen)
             pcall(function()
                 self.playback_bar:updateTimeDisplay(pos or 0, dur or 0)
             end)
-            -- Update chapter title and current chapter info
+            -- Update chapter title (overlay: SMIL chapter across audio parts)
             local ok_ch, ch, ch_idx = pcall(function() return self:getCurrentChapter() end)
-            if ok_ch and ch then
-                pcall(function()
-                    self.playback_bar:updateChapterTitle(ch.title or "")
-                    self.playback_bar:setCurrentChapter(ch)
-                end)
+            if ok_ch then
+                pcall(function() self:_refreshPlaybackBarTitles() end)
                 -- Update chapter menu highlight if it's open (chapter mode only;
                 -- playlist mode uses playlist index, not chapter index)
                 if self._chapter_menu and ch_idx and not self.playlist_files then
@@ -1592,6 +1638,9 @@ end
 
 function MediaSync:showPlaybackBar()
     if self.playback_bar and self.playback_bar:isVisible() then
+        -- Track transitions soft-stop and reuse the same player UI — refresh
+        -- the chapter label so we don't keep the first playlist entry forever.
+        self:_refreshPlaybackBarTitles()
         self:_reserveMiniBarSpace()
         return
     end
@@ -1612,17 +1661,27 @@ function MediaSync:showPlaybackBar()
             or self.plugin._smil_doc_path:match("([^/]+)$")
             or title
     end
-    -- Derive output name: use original playlist filename when available
+    -- Derive output name: book title in overlay mode (chapter goes in
+    -- chapter_title / mini bar). Standalone playlists keep the track name.
     local output_name = ""
-    if self.playlist_files and self.current_playlist_idx then
+    if self.overlay_mode then
+        output_name = title
+    elseif self.playlist_files and self.current_playlist_idx then
         output_name = self.playlist_files[self.current_playlist_idx].name
     elseif self.media_engine and self.media_engine.current_path then
         output_name = self.media_engine.current_path:match("([^/]+)$") or ""
     end
 
+    local initial_chapter = ""
+    if self.overlay_mode then
+        local ch = self:getCurrentChapter()
+        if ch and ch.title then initial_chapter = ch.title end
+    end
+
     local player = AudiobookPlayer:new{
         plugin = self.plugin,
         title = title,
+        chapter_title = initial_chapter,
         output_name = output_name,
         cover_image_path = self.cover_path,
         -- Read-along (EPUB overlay) mode: start minimized so the book page
@@ -1751,6 +1810,7 @@ function MediaSync:showPlaybackBar()
         end)
     end
     self.playback_bar = player
+    self:_refreshPlaybackBarTitles()
     self:_reserveMiniBarSpace()
 end
 
@@ -2039,14 +2099,9 @@ function MediaSync:showOverlayChapterList()
         return
     end
 
-    local current_time = self.media_engine and self.media_engine:getPosition() or 0
-    local current_path = self.media_engine and self.media_engine.current_path
     local current_idx = 1
-    for i, ch in ipairs(chapters) do
-        if ch.audio_path == current_path and ch.start_time <= current_time + 1 then
-            current_idx = i
-        end
-    end
+    local _, idx = self:_resolveOverlayChapter()
+    if idx then current_idx = idx end
 
     local items = {}
     for i, ch in ipairs(chapters) do
@@ -2150,6 +2205,12 @@ end
 -- ---------------------------------------------------------------------------
 
 function MediaSync:getCurrentChapter()
+    -- Storyteller / Media Overlay: prefer the flat SMIL chapter list so the
+    -- title follows the content document across ~4 min audio-file boundaries.
+    if self.overlay_mode then
+        local ch, idx = self:_resolveOverlayChapter()
+        if ch then return ch, idx end
+    end
     if not self.chapters or #self.chapters == 0 then return nil end
     local pos = self.media_engine:getPosition()
     for i = #self.chapters, 1, -1 do

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -640,8 +640,12 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
             end
         end
     end
-    self._current_sentence_idx = 1
-    self._current_word_idx = 1
+    -- 0 so the first sync tick (sentence 1) enters the highlight / page-follow
+    -- path.  Previously this was 1, which skipped the opening sentence.
+    self._current_sentence_idx = 0
+    self._current_word_idx = 0
+    self._last_hl_idx = nil
+    self._last_page_advance_idx = nil
     self._chain_generation = self._chain_generation + 1
     self._last_progress_pct = -1
     self._last_ui_update_time = nil
@@ -749,6 +753,9 @@ function MediaSync:stop(keep_chapter_menu)
     if self.playback_bar then
         pcall(function() self.playback_bar:hide() end)
     end
+    if self.plugin and self.plugin._hideReturnToReadAloudButton then
+        pcall(function() self.plugin:_hideReturnToReadAloudButton() end)
+    end
     if not keep_chapter_menu then
         if self._chapter_menu_window then
             pcall(function() UIManager:close(self._chapter_menu_window) end)
@@ -774,6 +781,13 @@ function MediaSync:pause(auto)
         pcall(function() self.playback_bar:setPlaying(false) end)
     end
     logger.dbg("MediaSync: paused", auto and "(auto)" or "")
+end
+
+function MediaSync:clearSentenceHighlight()
+    if self.highlight_manager then
+        pcall(function() self.highlight_manager:clearHighlights() end)
+        self.highlight_manager._line_cache = nil
+    end
 end
 
 function MediaSync:resume(auto)
@@ -1096,22 +1110,6 @@ function MediaSync:_updateHighlightAtTime(pos)
                 self.plugin._suppress_media_sync_auto_page_follow = nil
             end
         end
-        if sentence.fragment_id and follow_page_turns and not suppress_auto_follow then
-            local ui = self.plugin and self.plugin.ui
-            if ui and ui.rolling and ui.document then
-                pcall(function()
-                    self:_markPageFollowAuto()
-                    local ms = self
-                    local ok = self:_gotoSmilFragment(sentence.text_doc, sentence.fragment_id, false, sentence.text)
-                    if not ok then
-                        logger.dbg("MediaSync: page-follow failed for", sentence.fragment_id)
-                    end
-                    UIManager:scheduleIn(2.5, function()
-                        ms:_clearPageFollowAuto()
-                    end)
-                end)
-            end
-        end
         if self.highlight_manager and sentence.text then
             -- Build a synthetic sentence object for HighlightManager
             local sent_obj = {
@@ -1126,60 +1124,72 @@ function MediaSync:_updateHighlightAtTime(pos)
             if hl_ok and sentence.fragment_id then
                 self:_cacheResolvedXPointer(sentence.text_doc, sentence.fragment_id)
             end
-            -- Read-along page advancement: narration flows forward, so when
-            -- the next sequential sentence is not on the visible page it is
-            -- on the following one -- turn and retry once.  Only for
-            -- sequential advancement (not seeks), so a failed text match
-            -- can never page away from where the user is reading.
-            if not hl_ok and self.overlay_mode
-                and sent_idx == (self._last_hl_idx or 0) + 1
+
+            -- If the sentence is not on the visible page, JUMP to its fragment
+            -- (spine/TOC/findText).  Never crawl with GotoViewRel on every
+            -- sentence — that freezes Kindle touch input for minutes.
+            local jump_pending = false
+            if not hl_ok and self.overlay_mode and sentence.fragment_id
                 and follow_page_turns and not suppress_auto_follow then
                 local ui = self.plugin and self.plugin.ui
-                if ui then
-                    local expected_n = self:_getExpectedDocFragmentIndex(sentence.text_doc)
-                    local cur_frag = nil
-                    if ui.document then
-                        local cur_xp = ui.document:getXPointer()
-                        cur_frag = cur_xp and tonumber(cur_xp:match("DocFragment%[(%d+)%]"))
-                    end
-                    local cross_doc = expected_n and cur_frag and expected_n ~= cur_frag
-                    if cross_doc and sentence.fragment_id then
-                        pcall(function()
-                            self:_markPageFollowAuto()
-                            local ms = self
-                            self:_gotoSmilFragment(sentence.text_doc, sentence.fragment_id, true, sentence.text)
-                            UIManager:scheduleIn(0.3, function()
-                                pcall(function()
-                                    self.highlight_manager:highlightSentence(sent_obj, {sentences = {sent_obj}})
-                                end)
-                            end)
-                            UIManager:scheduleIn(2.5, function()
-                                ms:_clearPageFollowAuto()
-                            end)
-                        end)
-                    elseif not cross_doc then
-                        pcall(function()
-                            self:_markPageFollowAuto()
-                            local ms = self
-                            ui:handleEvent(Event:new("GotoViewRel", 1))
-                            self.highlight_manager:highlightSentence(sent_obj, {sentences = {sent_obj}})
-                            if sentence.fragment_id then
-                                self:_cacheResolvedXPointer(sentence.text_doc, sentence.fragment_id)
+                if ui and ui.rolling and ui.document then
+                    jump_pending = true
+                    pcall(function()
+                        self:_markPageFollowAuto()
+                        local ms = self
+                        local target_idx = sent_idx
+                        -- allow_scan=true: direct DocFragment jump, not +1 page.
+                        local jumped = self:_gotoSmilFragment(
+                            sentence.text_doc, sentence.fragment_id, true, sentence.text)
+                        if not jumped then
+                            -- Last resort: a single relative page turn, and only
+                            -- when advancing exactly one sentence (not a seek).
+                            if sent_idx == (self._last_hl_idx or 0) + 1
+                                and self._last_page_advance_idx ~= sent_idx then
+                                self._last_page_advance_idx = sent_idx
+                                ui:handleEvent(Event:new("GotoViewRel", 1))
                             end
-                            UIManager:scheduleIn(2.5, function()
+                        end
+                        if ms.highlight_manager then
+                            ms.highlight_manager._line_cache = nil
+                        end
+                        UIManager:scheduleIn(0.35, function()
+                            if ms.state ~= ms.STATE.PLAYING then
+                                ms:_clearPageFollowAuto()
+                                return
+                            end
+                            if ms._current_sentence_idx ~= target_idx then
+                                ms:_clearPageFollowAuto()
+                                return
+                            end
+                            local retry_ok = false
+                            pcall(function()
+                                retry_ok = ms.highlight_manager:highlightSentence(
+                                    sent_obj, {sentences = {sent_obj}})
+                            end)
+                            if retry_ok then
+                                ms._last_hl_idx = target_idx
+                                ms:_cacheResolvedXPointer(
+                                    sentence.text_doc, sentence.fragment_id)
+                            else
+                                pcall(function()
+                                    ms.highlight_manager:clearHighlights()
+                                end)
+                            end
+                            UIManager:scheduleIn(2.0, function()
                                 ms:_clearPageFollowAuto()
                             end)
                         end)
-                    end
+                    end)
                 end
             end
-            -- If the sentence is genuinely not on the visible page and we
-            -- didn't auto-advance, clear the stale highlight so it isn't
-            -- mirrored at the wrong x,y on the current page.
-            if not hl_ok then
+
+            if not hl_ok and not jump_pending then
                 pcall(function() self.highlight_manager:clearHighlights() end)
             end
-            self._last_hl_idx = sent_idx
+            if hl_ok or not jump_pending then
+                self._last_hl_idx = sent_idx
+            end
         end
     end
 
@@ -1498,6 +1508,9 @@ function MediaSync:showPlaybackBar()
         end,
         on_refocus = self.overlay_mode and function()
             self:refocusToCurrentSentence()
+            if self.plugin and self.plugin._hideReturnToReadAloudButton then
+                pcall(function() self.plugin:_hideReturnToReadAloudButton() end)
+            end
         end or nil,
     }
     player:show()
@@ -1510,50 +1523,81 @@ function MediaSync:showPlaybackBar()
     self.playback_bar = player
 end
 
-function MediaSync:navigateToSentenceAtTime(seconds)
-    if not self.overlay_mode then return end
-    if not self.timing_data then return end
+function MediaSync:navigateToSentenceEntry(entry)
+    -- Jump to a specific SMIL timing entry by fragment id (preferred for
+    -- "Play aligned from here", where looking up by start_time can hit the
+    -- wrong sentence when several share similar clip times).
+    if not self.overlay_mode or not self.timing_data or not entry then return false end
     local ui = self.plugin and self.plugin.ui
-    if not ui or not ui.rolling or not ui.document then return end
+    if not ui or not ui.rolling or not ui.document then return false end
 
-    local sent_idx = self:_findSentenceAtTime(seconds)
-    if not sent_idx then
-        logger.warn("MediaSync: navigateToSentenceAtTime found no sentence at", seconds)
-        return
+    local sent_idx = nil
+    if entry.fragment_id then
+        for i, e in ipairs(self.timing_data) do
+            if e.fragment_id == entry.fragment_id
+                and (not entry.text_doc or e.text_doc == entry.text_doc) then
+                sent_idx = i
+                break
+            end
+        end
     end
-    local sentence = self.timing_data[sent_idx]
+    if not sent_idx and entry.start_time then
+        sent_idx = self:_findSentenceAtTime(entry.start_time)
+    end
+    local sentence = sent_idx and self.timing_data[sent_idx]
     if not sentence or not sentence.fragment_id then
-        logger.warn("MediaSync: navigateToSentenceAtTime no fragment for sentence", sent_idx)
-        return
+        logger.warn("MediaSync: navigateToSentenceEntry: no matching sentence")
+        return false
     end
+
     self._current_sentence_idx = sent_idx
-    logger.warn("MediaSync: navigating to sentence", sent_idx, sentence.text_doc, sentence.fragment_id)
+    self._last_hl_idx = sent_idx
+    logger.warn("MediaSync: navigating to entry", sent_idx, sentence.text_doc, sentence.fragment_id)
+
+    if self.plugin and time then
+        self.plugin._suppress_media_sync_auto_page_follow = time.now() + time.s(3.0)
+    end
 
     self:_markPageFollowAuto()
     local ms = self
     local nav_ok = self:_gotoSmilFragment(sentence.text_doc, sentence.fragment_id, true, sentence.text)
     if not nav_ok then
-        logger.warn("MediaSync: navigateToSentenceAtTime failed for", sentence.text_doc, sentence.fragment_id)
+        logger.warn("MediaSync: navigateToSentenceEntry failed for", sentence.fragment_id)
         self:_clearPageFollowAuto()
-        return
+        return false
     end
     UIManager:scheduleIn(2.5, function()
         ms:_clearPageFollowAuto()
     end)
 
-    -- Re-highlight the sentence after the page settles.
     if self.highlight_manager and sentence.text then
         local sent_obj = {
             text = sentence.text,
             start_pos = sentence.start_pos or 0,
             end_pos = sentence.end_pos or #sentence.text,
         }
+        self.highlight_manager._line_cache = nil
         UIManager:scheduleIn(0.3, function()
             pcall(function()
-                self.highlight_manager:highlightSentence(sent_obj, {sentences = {sent_obj}})
+                local ok = ms.highlight_manager:highlightSentence(sent_obj, {sentences = {sent_obj}})
+                if ok then
+                    ms:_cacheResolvedXPointer(sentence.text_doc, sentence.fragment_id)
+                end
             end)
         end)
     end
+    return true
+end
+
+function MediaSync:navigateToSentenceAtTime(seconds)
+    if not self.overlay_mode then return end
+    if not self.timing_data then return end
+    local sent_idx = self:_findSentenceAtTime(seconds)
+    if not sent_idx then
+        logger.warn("MediaSync: navigateToSentenceAtTime found no sentence at", seconds)
+        return
+    end
+    self:navigateToSentenceEntry(self.timing_data[sent_idx])
 end
 
 function MediaSync:refocusToCurrentSentence()

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -1110,12 +1110,14 @@ function MediaSync:_updateHighlightAtTime(pos)
                 self.plugin._suppress_media_sync_auto_page_follow = nil
             end
         end
-        if self.highlight_manager and sentence.text then
+        if self.highlight_manager and (sentence.text or sentence.fragment_id) then
             -- Build a synthetic sentence object for HighlightManager
             local sent_obj = {
-                text = sentence.text,
+                text = sentence.text or "",
                 start_pos = sentence.start_pos or 0,
-                end_pos = sentence.end_pos or #sentence.text,
+                end_pos = sentence.end_pos or #(sentence.text or ""),
+                fragment_id = sentence.fragment_id,
+                text_doc = sentence.text_doc,
             }
             local hl_ok = false
             pcall(function()
@@ -1216,6 +1218,7 @@ end
 
 function MediaSync:_findSentenceAtTime(pos)
     local data = self.timing_data
+    if not data or #data == 0 then return nil end
     local lo, hi = 1, #data
     while lo <= hi do
         local mid = math.floor((lo + hi) / 2)
@@ -1235,6 +1238,14 @@ function MediaSync:_findSentenceAtTime(pos)
     -- If before the beginning, return first
     if pos < data[1].start_time then
         return 1
+    end
+    -- Gap between clips (Storyteller sometimes leaves tiny holes): keep the
+    -- last sentence that has already started so the highlight does not blink off.
+    if hi >= 1 and hi <= #data and data[hi].start_time <= pos then
+        return hi
+    end
+    if lo >= 1 and lo <= #data and data[lo].start_time <= pos then
+        return lo
     end
     return nil
 end
@@ -1570,11 +1581,13 @@ function MediaSync:navigateToSentenceEntry(entry)
         ms:_clearPageFollowAuto()
     end)
 
-    if self.highlight_manager and sentence.text then
+    if self.highlight_manager and (sentence.text or sentence.fragment_id) then
         local sent_obj = {
-            text = sentence.text,
+            text = sentence.text or "",
             start_pos = sentence.start_pos or 0,
-            end_pos = sentence.end_pos or #sentence.text,
+            end_pos = sentence.end_pos or #(sentence.text or ""),
+            fragment_id = sentence.fragment_id,
+            text_doc = sentence.text_doc,
         }
         self.highlight_manager._line_cache = nil
         UIManager:scheduleIn(0.3, function()
@@ -1646,11 +1659,13 @@ function MediaSync:refocusToCurrentSentence()
     end)
 
     -- Re-highlight the current sentence after the page settles.
-    if self.highlight_manager and sentence.text then
+    if self.highlight_manager and (sentence.text or sentence.fragment_id) then
         local sent_obj = {
-            text = sentence.text,
+            text = sentence.text or "",
             start_pos = sentence.start_pos or 0,
-            end_pos = sentence.end_pos or #sentence.text,
+            end_pos = sentence.end_pos or #(sentence.text or ""),
+            fragment_id = sentence.fragment_id,
+            text_doc = sentence.text_doc,
         }
         UIManager:scheduleIn(0.3, function()
             pcall(function()


### PR DESCRIPTION
## Summary

Full Storyteller EPUB3 Media Overlay read-aloud support for KOReader (validated on Kindle + Bose QuietComfort Ultra Gen1, later AirPods Pro 3).

Fixes the previous `"no timing data extracted"` failures and later highlight/narration desync after Storyteller re-exports. Follow-up field tests (Aug 2026) also fixed **manual page-turn seeking audio** (must not restart/jump tracks) and status-bar UX.

### Core parsing
- Multiline SMIL/OPF (`RE_ANY_LAZY`) ÔÇö Lua `.` does not match newlines
- Info-ZIP bracket escape (`[` ÔåÆ `[[]`) for Storyteller paths like `Author-[Series-1]Title...smil`
- `_compactXml()` safety for pretty-printed XML
- Spine-ordered SMIL parse; nested `<span>` text extraction

### Playback / UX
- Live SMIL load progress on e-ink (`forceRePaint`)
- **Play aligned from here** via fragment id + scored text match (no crawl)
- Page-follow without `GotoViewRel` freeze
- **Manual page turns never seek/restart audio** ÔÇö highlighting pauses, **Return to read-aloud** cue on the mini bar; auto-follow resumes on return or when narration catches up
- Soft track transitions for multi-file Storyteller audio (playlist parts are Storyteller chunks, not Kindle-invented)
- Player title = book title (not first SMIL sentence text)
- ÔÅ¡/ÔÅ« in overlay mode = SMIL content-document chapters (not raw ~4 min audio parts)
- Chapter list jumps across audio files without losing the session
- EPUB size+mtime fingerprint ÔåÆ wipe stale `cache/overlays/` when the book is re-exported in place
- Fragment-id highlighting (Readest-style) preferred over fuzzy text match
- Optional **Keep status bars during read-aloud** ÔÇö mini player sits above KOReaderÔÇÖs bottom status / progress bar
- **Page margin reserve for mini player** (v0.1.17.23) ÔÇö CRE reflows so book text ends above the mini player (same idea as TTS `_reserveBarSpace`); the overlay never covers readable text even with status + alt status + progress bars enabled

## Manual tests (Kindle + Bose QuietComfort Ultra Gen1 / AirPods Pro 3)

All verified working:

- [x] **Cold start** ÔÇö KOReader restart, open *Le Roi de fer*, Play aligned/enriched audiobook; SMIL loads with live progress (no `"no timing data"`)
- [x] **Highlight sync** ÔÇö first sentences highlight correctly; page auto-follow stays on the spoken sentence
- [x] **Play aligned from here** ÔÇö long-press mid-chapter; audio starts at that sentence
- [x] **Return to read-aloud** ÔÇö browse away while playing/paused; mini bar shows *Return to read-aloud*; tap / ÔùÄ restores position + highlight; **audio keeps playing** (no seek/restart)
- [x] **Manual page turn mid-chapter** ÔÇö peek ahead: no audio jump to earlier track; highlight off + return cue
- [x] **Pause + browse** ÔÇö pause, change page: no stale highlight; return cue works
- [x] **Seek / skip** ÔÇö sentence/chapter controls stay aligned with text
- [x] **Chapter list** ÔÇö jump lands on correct text + audio
- [x] **Natural multi-file advance** ÔÇö Storyteller ~4 min audio parts chain (A2DP bridge covered in companion AirPods PR when needed)
- [x] **Resume after close** ÔÇö reopen book, resume near last position
- [x] **Re-export / cache** ÔÇö regenerating the Storyteller EPUB invalidates stale overlay audio cache; highlights match new alignment
- [x] **Bluetooth audio** ÔÇö Bose QuietComfort Ultra (Gen1) and AirPods Pro 3; sync/highlights track audible narration
- [x] **Keep status bars** ÔÇö with bottom status + progress (+ alt status bar), mini player sits in reserved chrome; book text reflows above it (v0.1.17.23)

## Automated / fixture checks

- [x] `luajit dev/test_epubmediaoverlay_multiline.lua` smoke test
- [x] Storyteller EPUB with bracketed filenames (*Le Roi de fer*)
- [x] Timing extraction non-zero after parse

## Notes

- Deploy: `koreader/plugins/audiobook.koplugin/` ÔÇö full KOReader restart after update
- First play after EPUB change re-extracts embedded audio (~hundreds of MB); expected
- Storyteller embeds many short audio files inside the EPUB; the plugin plays them as a playlist (Readest presents one continuous timeline)
- Related: #32; companion AirPods A2DP PR for Kindle PW11 idle-route drops; Readest reference: [readest/readest#5562](https://github.com/readest/readest/pull/5562)
