### PR TITLE
Fix AirPods Pro 3 A2DP dropout on Kindle (brief sound then silence)

### DIFF
--- a/PR_BODY_AIRPODS.md
+++ b/PR_BODY_AIRPODS.md
@@ -14,6 +14,7 @@ Root cause: Kindle `audiomgrd` drops the A2DP datapath when `mixersink` goes idl
 - Cached headset MAC (`ListConnected` → `ListPaired` → last-seen) so BT cycles don’t skip with “no connected MAC”
 - Menu: **Bluetooth settings → Reconnect BT on track change** (`kindle_bt_reconnect_on_track`, **off by default**) — optional forced Disconnect→Connect (~5–10 s) before the next file; keepalive still runs either way
 - Overlay **BT** shortcut button removed (v0.1.17.22); use the menu setting / plugin BT menu instead
+- Companion Storyteller UX (same field device): mini-player **page-margin reserve** so read-aloud chrome never covers book text when status/progress bars stay visible (v0.1.17.23; full page-turn / status-bar UX lives in the Storyteller PR)
 - Bug report: Apple headset detection, `btfd` lists, input devices, `btui` probe
 - Field doc: [`docs/AIRPODS_PRO3_KINDLE.md`](docs/AIRPODS_PRO3_KINDLE.md)
 

--- a/PR_BODY_AIRPODS.md
+++ b/PR_BODY_AIRPODS.md
@@ -1,0 +1,30 @@
+## Summary
+
+Hardens Kindle A2DP playback for **Apple AirPods Pro 3** (Paperwhite 11th gen field tests).
+
+Fixes the “hear a blip, then permanent silence” failure and the later **pause → play = silent until BT reconnect** failure by keeping the A2DP datapath alive and re-arming the route when needed.
+
+### Changes
+- Skip redundant `seek-by-restart` / stop orphan-killing on PID-capture miss; recover PID via `pgrep`
+- AirPods-aware `adelay`/`apad`, Music-focus reclaim, A2DP watchdog
+- **Pause keepalive** (silence on `mixersink`, same idea as TTS) + resume with optional **Disconnect/Connect** cycle when `audioOutputConnected` stays down
+- Bug report: Apple headset detection, `btfd` lists, input devices, `btui` probe
+- Field doc: [`docs/AIRPODS_PRO3_KINDLE.md`](../blob/pr/airpods-pro3-a2dp/docs/AIRPODS_PRO3_KINDLE.md)
+
+### Known limitation
+**AirPods stem Play/Pause does not work on Kindle PW11.** No AVRCP input device / no `btui` on this firmware. Stem volume and ANC still work. Use on-screen / Kindle controls. Details and future research notes are in the doc. Kobo Libra Colour is a better candidate for stem AVRCP (existing `mtkbtd` path).
+
+## Manual tests (Kindle Paperwhite 11 + AirPods Pro 3)
+
+- [x] First play after connect — audio continues past 1–2 s
+- [x] Pause (UI) several seconds → Play — audio returns
+- [x] Longer pause (~2 min) → Play — audio returns (keepalive)
+- [x] Seek / chapter jump while playing
+- [x] Plugin BT Disconnect/Connect restores stale A2DP route
+- [x] Bug report shows `kindle_apple_headset` / connected lists
+- [x] Stem volume ± and ANC — work (system / headset)
+- [ ] Stem Play/Pause — **not available** on this Kindle firmware (documented)
+
+## Related
+- Storyteller EPUB3 overlay PR (separate): multiline SMIL / UX — tested on same Kindle with Bose QC Ultra Gen1 and AirPods
+- Platform overview: `docs/PLATFORM_AUDIO.md`

--- a/PR_BODY_AIRPODS.md
+++ b/PR_BODY_AIRPODS.md
@@ -1,30 +1,39 @@
 ## Summary
 
-Hardens Kindle A2DP playback for **Apple AirPods Pro 3** (Paperwhite 11th gen field tests).
+Hardens Kindle A2DP playback for **Apple AirPods Pro 3** on a jailbroken **Paperwhite 11th gen** (KOReader field tests, Aug 2026).
 
-Fixes the “hear a blip, then permanent silence” failure and the later **pause → play = silent until BT reconnect** failure by keeping the A2DP datapath alive and re-arming the route when needed.
+Fixes the “blip then permanent silence” failure, **pause → play silence until BT reconnect**, and **EOS / playlist-chunk silence** when Storyteller (or any multi-file) audio advances to the next embedded part.
+
+Root cause: Kindle `audiomgrd` drops the A2DP datapath when `mixersink` goes idle across stop→play gaps (seek-by-restart, pause, track advance). Manual Disconnect/Connect re-arms the route; the plugin now bridges that gap.
 
 ### Changes
 - Skip redundant `seek-by-restart` / stop orphan-killing on PID-capture miss; recover PID via `pgrep`
 - AirPods-aware `adelay`/`apad`, Music-focus reclaim, A2DP watchdog
-- **Pause keepalive** (silence on `mixersink`, same idea as TTS) + resume with optional **Disconnect/Connect** cycle when `audioOutputConnected` stays down
+- **Pause keepalive** (silence on `mixersink`, same idea as TTS) + resume with optional **Disconnect/Connect** when `audioOutputConnected` stays down
+- **Track-advance bridge**: soft-stop keeps keepalive + player UI across playlist/Storyteller file changes (hard stop was killing the bridge and leaving Play dead in `STOPPED`)
+- Cached headset MAC (`ListConnected` → `ListPaired` → last-seen) so BT cycles don’t skip with “no connected MAC”
+- Menu: **Bluetooth settings → Reconnect BT on track change** (`kindle_bt_reconnect_on_track`, **off by default**) — optional forced Disconnect→Connect (~5–10 s) before the next file; keepalive still runs either way
+- Overlay **BT** shortcut button removed (v0.1.17.22); use the menu setting / plugin BT menu instead
 - Bug report: Apple headset detection, `btfd` lists, input devices, `btui` probe
-- Field doc: [`docs/AIRPODS_PRO3_KINDLE.md`](../blob/pr/airpods-pro3-a2dp/docs/AIRPODS_PRO3_KINDLE.md)
+- Field doc: [`docs/AIRPODS_PRO3_KINDLE.md`](docs/AIRPODS_PRO3_KINDLE.md)
 
 ### Known limitation
-**AirPods stem Play/Pause does not work on Kindle PW11.** No AVRCP input device / no `btui` on this firmware. Stem volume and ANC still work. Use on-screen / Kindle controls. Details and future research notes are in the doc. Kobo Libra Colour is a better candidate for stem AVRCP (existing `mtkbtd` path).
+**AirPods stem Play/Pause does not work on Kindle PW11.** No AVRCP input device / no `btui` on this firmware. Stem volume and ANC still work. Use on-screen / Kindle controls. Details in the doc. Kobo Libra Colour is a better candidate for stem AVRCP (existing `mtkbtd` path).
 
 ## Manual tests (Kindle Paperwhite 11 + AirPods Pro 3)
 
 - [x] First play after connect — audio continues past 1–2 s
 - [x] Pause (UI) several seconds → Play — audio returns
 - [x] Longer pause (~2 min) → Play — audio returns (keepalive)
-- [x] Seek / chapter jump while playing
+- [x] Seek / ±30s while playing — audio continues (seek-bridge)
+- [x] Natural EOS → next Storyteller audio part (~4 min chunks) — audio resumes with keepalive; optional BT reconnect setting validated when enabled
 - [x] Plugin BT Disconnect/Connect restores stale A2DP route
+- [x] **Reconnect BT on track change** (menu) — works well across chunk boundaries
+- [x] Play from `STOPPED` after a botched transition — restarts current file
 - [x] Bug report shows `kindle_apple_headset` / connected lists
 - [x] Stem volume ± and ANC — work (system / headset)
 - [ ] Stem Play/Pause — **not available** on this Kindle firmware (documented)
 
 ## Related
-- Storyteller EPUB3 overlay PR (separate): multiline SMIL / UX — tested on same Kindle with Bose QC Ultra Gen1 and AirPods
+- Storyteller EPUB3 overlay PR (separate): multiline SMIL / read-aloud UX — tested on same Kindle with Bose QC Ultra Gen1 and AirPods Pro 3
 - Platform overview: `docs/PLATFORM_AUDIO.md`

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ On MTK devices the BT audio pipeline uses an exclusive abstract socket. If audio
 > On MTK Kobo devices, the mtkbtmwrpc daemon binds a single abstract socket. Only one GStreamer pipeline can hold it at a time. The plugin keeps one persistent pipeline alive across sentences to avoid reconnection gaps. On BlueZ devices, the plugin starts `bluetoothd` and resets the HCI adapter automatically when you power on Bluetooth.
 > **Known issue on MTK devices:** MBROLA voices other than `mb-en1` (UK English Male 1) may produce mid-sentence audio repeats due to a firmware bug in the MTK Bluetooth SBC encoder. This affects all MBROLA voices except `mb-en1`. See [docs/MBROLA_MTK_REPEAT_BUG.md](docs/MBROLA_MTK_REPEAT_BUG.md) for the full diagnostic report.
 
-For the full platform audio and Bluetooth architecture (Kobo generations, Kindle, Android), see [docs/PLATFORM_AUDIO.md](docs/PLATFORM_AUDIO.md).
+For the full platform audio and Bluetooth architecture (Kobo generations, Kindle, Android), see [docs/PLATFORM_AUDIO.md](docs/PLATFORM_AUDIO.md). AirPods Pro 3 on Kindle Paperwhite 11 (what works, pause/resume keepalive, stem Play/Pause limitation): [docs/AIRPODS_PRO3_KINDLE.md](docs/AIRPODS_PRO3_KINDLE.md).
 
 ## Playback controls
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.18",
+    version = "0.1.17.22",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.15",
+    version = "0.1.17.16",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.16",
+    version = "0.1.17.17",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.17",
+    version = "0.1.17.18",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.14",
+    version = "0.1.17.15",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.22",
+    version = "0.1.17.23",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -62,6 +62,8 @@ local AudiobookPlayer = InputContainer:extend{
     on_skip_forward = nil,
     on_fix_audio = nil,
     show_fix_audio = false,
+    -- When true, mini bar sits above KOReader's bottom status bar.
+    keep_reader_status_bars = false,
     on_prev_chapter = nil,
     on_next_chapter = nil,
     on_seek = nil,
@@ -144,6 +146,11 @@ function AudiobookPlayer:init()
     self.height = Screen:getHeight()
     self.dimen = Geom:new{ w = self.width, h = self.height }
     self._minimized = false
+    -- Do not claim the whole screen / footer while the mini player is up —
+    -- otherwise ReaderFooter may skip updates ("lost" status bar).
+    self.covers_fullscreen = false
+    self.covers_footer = not self.keep_reader_status_bars
+    self._return_hint_active = false
     self._rotation_mode = Screen:getRotationMode()
     self:setupUI()
 end
@@ -726,11 +733,40 @@ function AudiobookPlayer:setupUI()
     -- follow are the UI) with only the mini bar for transport control,
     -- instead of covering the text with the full-screen player.
     if self.start_minimized then
-        self._minimized = true
-        self.dimen.h = self._mini_height
-        self.dimen.y = self.height - self._mini_height
+        self:_applyMinimizedGeometry()
         self:_updateMiniWidgets()
     end
+end
+
+--- Bottom inset so the mini player can sit above KOReader's status/progress bar.
+--- MediaSync also reflows page margins by this chrome height + mini bar so
+--- book text never renders underneath the player.
+function AudiobookPlayer:_statusBarInset()
+    if not self.keep_reader_status_bars then return 0 end
+    local ui = self.plugin and self.plugin.ui
+    local view = ui and ui.view
+    if not view or not view.footer_visible or not view.footer then return 0 end
+    local ok, h = pcall(function() return view.footer:getHeight() end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    ok, h = pcall(function()
+        local d = view.footer.dimen
+        return d and d.h or 0
+    end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    -- Last resort: typical status+progress stack on PW11-class screens.
+    return Screen:scaleBySize(36)
+end
+
+function AudiobookPlayer:_miniBarY()
+    return self.height - self._mini_height - self:_statusBarInset()
+end
+
+function AudiobookPlayer:_applyMinimizedGeometry()
+    self._minimized = true
+    self.covers_fullscreen = false
+    self.covers_footer = not self.keep_reader_status_bars
+    self.dimen.h = self._mini_height
+    self.dimen.y = self:_miniBarY()
 end
 
 -- Callback handlers
@@ -759,14 +795,12 @@ function AudiobookPlayer:onClose()
 end
 
 function AudiobookPlayer:onMinimize()
-    self._minimized = true
     self._scrubber_dragging = false
     self._scrubber_drag_pct = nil
     self:_updateMiniWidgets()
     -- Shrink dimen to only cover the mini bar area at the bottom
     -- so touch events pass through to the rest of the screen.
-    self.dimen.h = self._mini_height
-    self.dimen.y = self.height - self._mini_height
+    self:_applyMinimizedGeometry()
     logger.warn("AudiobookPlayer: minimized, dimen=",
         self.dimen.x, self.dimen.y, self.dimen.w, self.dimen.h)
     -- Full refresh to erase the full-screen player image and redraw only the
@@ -779,6 +813,9 @@ function AudiobookPlayer:_restore()
     self._minimized = false
     self._scrubber_dragging = false
     self._scrubber_drag_pct = nil
+    -- Full-screen player covers the book (and status bars) while expanded.
+    self.covers_fullscreen = true
+    self.covers_footer = true
     -- Restore dimen to full screen so we receive all events again
     self.dimen.h = self.height
     self.dimen.y = 0
@@ -1321,15 +1358,48 @@ function AudiobookPlayer:_updateScrubberPreview(x)
 end
 
 function AudiobookPlayer:_updateMiniWidgets()
-    -- Show track filename (output_name) in mini bar; fall back to title
-    local track = self.output_name
-    if not track or track == "" then
-        track = self.title or _("Audiobook")
+    -- Show track filename (output_name) in mini bar; fall back to title.
+    -- When browsing away from the audio page, the title becomes a clear
+    -- "Return to read-aloud" cue (tapping the bar centers on the sentence).
+    local track
+    if self._return_hint_active then
+        track = _("Return to read-aloud")
+    else
+        track = self.output_name
+        if not track or track == "" then
+            track = self.title or _("Audiobook")
+        end
     end
-    self._mini_title:setText(track)
-    self._mini_time:setText(self.current_time_str or "")
-    local txt = self.is_playing and "⏸" or "▶"
-    self._mini_play_pause:setText(txt, self._mini_play_pause.width)
+    if self._mini_title then
+        self._mini_title:setText(track)
+    end
+    if self._mini_time then
+        self._mini_time:setText(self.current_time_str or "")
+    end
+    if self._mini_play_pause then
+        local txt = self.is_playing and "⏸" or "▶"
+        self._mini_play_pause:setText(txt, self._mini_play_pause.width)
+    end
+    if self._mini_refocus then
+        -- Make the existing ○ control more obvious while the hint is active.
+        local label = self._return_hint_active and "◎" or "○"
+        self._mini_refocus:setText(label, self._mini_refocus.width)
+    end
+end
+
+--- Toggle Readest-style "return to read-aloud" cue on the mini bar.
+-- When active, tapping the mini bar (outside transport buttons) refocuses
+-- instead of expanding the full player.
+function AudiobookPlayer:setReturnHint(active)
+    active = not not active
+    if self._return_hint_active == active then return end
+    self._return_hint_active = active
+    if self._minimized then
+        self:_updateMiniWidgets()
+        UIManager:setDirty(self, function()
+            return "ui", self.dimen
+        end)
+    end
 end
 
 -- Show / hide
@@ -1402,8 +1472,9 @@ function AudiobookPlayer:handleEvent(event)
                 self.plugin.session_recorder:recordGesture(ges, "audiobookplayer")
             end
             if ges and ges.pos then
-                local mini_y = self.height - self._mini_height
+                local mini_y = self:_miniBarY()
                 local on_bar = ges.pos.y >= mini_y
+                    and ges.pos.y < mini_y + self._mini_height
                 if on_bar and ges.ges == "tap" then
                     -- Tap on play/pause button?
                     if self:_isTapOnWidget(ges.pos, self._mini_play_pause) then
@@ -1459,6 +1530,14 @@ function AudiobookPlayer:handleEvent(event)
                         else
                             logger.warn("ABP: refocus button has no callback")
                         end
+                        return true
+                    end
+                    -- While browsing away from the narration page, a tap on
+                    -- the unused mini-bar area means "return to read-aloud"
+                    -- (same as ○), not "expand full player".
+                    if self._return_hint_active and self.on_refocus then
+                        logger.warn("ABP: return-hint bar tap -> refocus")
+                        self:onRefocus()
                         return true
                     end
                     -- Tap anywhere else on the mini bar -> restore full player
@@ -1662,11 +1741,12 @@ function AudiobookPlayer:_doRebuild(new_w, new_h)
     self:_updateMiniWidgets()
     -- Position at the correct coordinates for the new dimensions
     self.visible = true
-    self._minimized = was_minimized
     if was_minimized then
-        self.dimen.h = self._mini_height
-        self.dimen.y = self.height - self._mini_height
+        self:_applyMinimizedGeometry()
     else
+        self._minimized = false
+        self.covers_fullscreen = true
+        self.covers_footer = true
         self.dimen.h = self.height
         self.dimen.y = 0
     end
@@ -1716,11 +1796,11 @@ end
 function AudiobookPlayer:paintTo(bb, x, y)
     if not self.visible then return end
     if self._minimized then
-        -- Draw only the mini player bar at bottom.
+        -- Draw only the mini player bar at bottom (optionally above status bar).
         -- UIManager's window.y for this widget is always 0 (set when first shown),
         -- so we must add the bottom offset ourselves.
         if self._mini_bar and self._mini_bar.paintTo then
-            self._mini_bar:paintTo(bb, x or 0, (y or 0) + self.height - self._mini_height)
+            self._mini_bar:paintTo(bb, x or 0, (y or 0) + self:_miniBarY())
         end
         return
     end

--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -60,6 +60,8 @@ local AudiobookPlayer = InputContainer:extend{
     on_play_pause = nil,
     on_skip_back = nil,
     on_skip_forward = nil,
+    on_fix_audio = nil,
+    show_fix_audio = false,
     on_prev_chapter = nil,
     on_next_chapter = nil,
     on_seek = nil,
@@ -223,10 +225,22 @@ function AudiobookPlayer:setupUI()
         show_parent = self,
     }
 
+    -- Kindle AirPods: reconnect A2DP when the stream goes silent mid-play.
+    self.fix_audio_button = Button:new{
+        text = _("BT"),
+        width = button_size,
+        height = button_size,
+        text_font_size = 14,
+        callback = function() self:onFixAudio() end,
+        bordersize = 0,
+        show_parent = self,
+    }
+
     -- Count visible buttons for title width calculation
     local visible_buttons = 5 -- chapter_list, sleep_timer, speed, minimize, close
     if self.show_shuffle then visible_buttons = visible_buttons + 1 end
     if self.show_loop then visible_buttons = visible_buttons + 1 end
+    if self.show_fix_audio then visible_buttons = visible_buttons + 1 end
     self.title_widget = TextWidget:new{
         text = self.title or _("Audiobook"),
         face = Font:getFace("cfont", 18),
@@ -248,6 +262,10 @@ function AudiobookPlayer:setupUI()
     end
     if self.show_loop then
         table.insert(top_row_items, self.loop_button)
+        table.insert(top_row_items, HorizontalSpan:new{ width = math.floor(spacing / 2) })
+    end
+    if self.show_fix_audio then
+        table.insert(top_row_items, self.fix_audio_button)
         table.insert(top_row_items, HorizontalSpan:new{ width = math.floor(spacing / 2) })
     end
     table.insert(top_row_items, CenterContainer:new{
@@ -777,6 +795,10 @@ end
 
 function AudiobookPlayer:onLoop()
     if self.on_loop then self.on_loop() end
+end
+
+function AudiobookPlayer:onFixAudio()
+    if self.on_fix_audio then self.on_fix_audio() end
 end
 
 function AudiobookPlayer:onSeek(pct)

--- a/btmediacontrol.lua
+++ b/btmediacontrol.lua
@@ -84,6 +84,14 @@ function BtMediaControl.start(plugin)
         return true
     end
 
+    -- Kindle: no BlueZ AVRCP — advertise playback state via btui (if present)
+    -- and keep rescanning input nodes; AirPods stem needs an AVRCP target.
+    if Device.isKindle and Device:isKindle() then
+        logger.warn("BtMediaControl: Kindle AVRCP path (no BlueZ evdev)")
+        BtMediaControl._startKindleAvrcpSupport()
+        return true
+    end
+
     -- Fall back to D-Bus key monitoring
     logger.warn("BtMediaControl: No AVRCP evdev device found, trying D-Bus polling")
     BtMediaControl._startDbusPolling()
@@ -96,6 +104,7 @@ Stop listening for BT media button events.
 function BtMediaControl.stop()
     BtMediaControl._stopEvdev()
     BtMediaControl._stopDbusPolling()
+    BtMediaControl._stopKindleAvrcpSupport()
     BtMediaControl._plugin = nil
 end
 
@@ -150,41 +159,76 @@ function BtMediaControl._findAvrcpEvdevDevice()
         end
     end
 
-    -- Method 2: check /proc/bus/input/devices for AVRCP
+    -- Method 2: check /proc/bus/input/devices for AVRCP / media keys.
+    -- Blocks end at a blank line; KEY= usually appears after Handlers=.
     handle = io.popen("cat /proc/bus/input/devices 2>/dev/null")
     if handle then
         local output = handle:read("*a")
         handle:close()
-        -- Parse blocks separated by empty lines
-        local current_name = nil
-        local current_handlers = nil
-        for line in output:gmatch("[^\n]+") do
-            local name = line:match('^N: Name="(.-)"')
-            if name then
-                current_name = name
-                current_handlers = nil
-            end
-            local handlers = line:match("^H: Handlers=(.*)")
-            if handlers then
-                current_handlers = handlers
-            end
-            -- Check if this was an AVRCP device
-            if current_name and current_handlers
-                    and (current_name:lower():find("avrcp")
-                         or current_name:lower():find("media key")
-                         or current_name:lower():find("bluetooth.*key")) then
-                local event_dev = current_handlers:match("(event%d+)")
-                if event_dev then
-                    local dev_path = "/dev/input/" .. event_dev
-                    logger.warn("BtMediaControl: Found AVRCP in /proc/bus/input:",
-                        dev_path, "name:", current_name)
-                    return dev_path, current_name
-                end
+        local current_name, current_handlers, current_key_bitmap = nil, nil, nil
+        local function consider_block()
+            if not current_name or not current_handlers then return nil end
+            local lname = current_name:lower()
+            local name_hit = lname:find("avrcp", 1, true)
+                or lname:find("media key", 1, true)
+                or lname:find("consumer control", 1, true)
+                or lname:find("airpods", 1, true)
+                or lname:find("beats", 1, true)
+                or lname:find("headset", 1, true)
+                or lname:find("headphone", 1, true)
+            local key_hit = current_key_bitmap
+                and (BtMediaControl._keyBitmapHasCode(current_key_bitmap, KEY_PLAYPAUSE)
+                    or BtMediaControl._keyBitmapHasCode(current_key_bitmap, KEY_PLAYCD)
+                    or BtMediaControl._keyBitmapHasCode(current_key_bitmap, KEY_PAUSECD))
+            if not (name_hit or key_hit) then return nil end
+            local event_dev = current_handlers:match("(event%d+)")
+            if not event_dev then return nil end
+            local dev_path = "/dev/input/" .. event_dev
+            logger.warn("BtMediaControl: Found media input:",
+                dev_path, "name:", current_name,
+                "name_hit=", name_hit and "yes" or "no",
+                "key_hit=", key_hit and "yes" or "no")
+            return dev_path, current_name
+        end
+        for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+            if line == "" then
+                local path, name = consider_block()
+                if path then return path, name end
+                current_name, current_handlers, current_key_bitmap = nil, nil, nil
+            else
+                local name = line:match('^N: Name="(.-)"')
+                if name then current_name = name end
+                local handlers = line:match("^H: Handlers=(.*)")
+                if handlers then current_handlers = handlers end
+                local keys = line:match("^B: KEY=(.*)")
+                if keys then current_key_bitmap = keys end
             end
         end
+        local path, name = consider_block()
+        if path then return path, name end
     end
 
     return nil, nil
+end
+
+--- Return true if a /proc/bus/input/devices KEY= bitmap includes keycode.
+function BtMediaControl._keyBitmapHasCode(bitmap, keycode)
+    if not bitmap or not keycode then return false end
+    -- KEY= words are little-endian hex longs (native long width).  Use 32-bit
+    -- words as a practical common case on Kindle ARM; also try 64-bit.
+    local words = {}
+    for hex in bitmap:gmatch("%x+") do
+        table.insert(words, tonumber(hex, 16) or 0)
+    end
+    for _, bits_per_word in ipairs({32, 64}) do
+        local idx = math.floor(keycode / bits_per_word) + 1
+        local bit = keycode % bits_per_word
+        local word = words[idx]
+        if word and math.floor(word / (2 ^ bit)) % 2 == 1 then
+            return true
+        end
+    end
+    return false
 end
 
 --[[--
@@ -482,6 +526,87 @@ function BtMediaControl._dispatchMediaEvent(event_name)
 end
 
 
+-- ── Kindle AVRCP (AirPods stem / headset buttons) ────────────────────
+-- Kindle uses Lab126 btfd/Bluedroid, not BlueZ.  There is often no
+-- "(AVRCP)" evdev node.  We:
+--   1) advertise playback state via `btui` when available (AVRCP TG),
+--   2) periodically rescan /dev/input for media-key devices,
+--   3) poll lipc for playermgr / btfd hints that a remote command arrived.
+
+function BtMediaControl._startKindleAvrcpSupport()
+    if BtMediaControl._kindle_avrcp_active then return end
+    BtMediaControl._kindle_avrcp_active = true
+    BtMediaControl._kindleAdvertisePlaybackState("paused")
+    BtMediaControl._pollKindleAvrcp()
+end
+
+function BtMediaControl._stopKindleAvrcpSupport()
+    BtMediaControl._kindle_avrcp_active = false
+end
+
+function BtMediaControl._btuiAvailable()
+    if BtMediaControl._btui_checked then
+        return BtMediaControl._btui_path ~= nil
+    end
+    BtMediaControl._btui_checked = true
+    local h = io.popen("command -v btui 2>/dev/null; ls /usr/bin/btui 2>/dev/null")
+    if not h then return false end
+    local out = h:read("*a") or ""
+    h:close()
+    local path = out:match("(/[^\n]+btui)")
+    BtMediaControl._btui_path = path
+    return path ~= nil
+end
+
+--- Best-effort AVRCP target state via Amazon's btui test UI (menu 33).
+--- 1=stopped 2=paused 3=playing
+function BtMediaControl._kindleAdvertisePlaybackState(status)
+    if not BtMediaControl._btuiAvailable() then return end
+    local state = ({ playing = 3, paused = 2, stopped = 1 })[status] or 1
+    -- btui is an interactive menu; feed "33" (UpdatePlayBackState) + value + quit.
+    local cmd = string.format(
+        "( printf '33\\n%d\\n0\\n' | timeout 2 %s ) >/dev/null 2>&1 &",
+        state, BtMediaControl._btui_path or "btui")
+    os.execute(cmd)
+    logger.warn("BtMediaControl: Kindle btui UpdatePlayBackState", state, "(", status, ")")
+end
+
+function BtMediaControl._pollKindleAvrcp()
+    if not BtMediaControl._kindle_avrcp_active then return end
+
+    -- Late-appearing media input nodes after AirPods reconnect.
+    if not BtMediaControl._evdev_active then
+        if BtMediaControl._tryEvdevApproach() then
+            logger.warn("BtMediaControl: Kindle media input appeared on rescan")
+        end
+    end
+
+    -- Some firmwares toggle playermgr InPlayback when the headset sends AVRCP.
+    local h = io.popen("lipc-get-prop com.lab126.playermgr InPlayback 2>/dev/null")
+    if h then
+        local v = (h:read("*a") or ""):match("(%d+)")
+        h:close()
+        if v then
+            local n = tonumber(v)
+            if BtMediaControl._last_kindle_inplayback ~= nil
+                    and n ~= BtMediaControl._last_kindle_inplayback then
+                logger.warn("BtMediaControl: playermgr InPlayback",
+                    BtMediaControl._last_kindle_inplayback, "→", n)
+                if n == 0 then
+                    BtMediaControl._dispatchMediaEvent("MediaPause")
+                elseif n == 1 then
+                    BtMediaControl._dispatchMediaEvent("MediaPlay")
+                end
+            end
+            BtMediaControl._last_kindle_inplayback = n
+        end
+    end
+
+    if BtMediaControl._kindle_avrcp_active then
+        UIManager:scheduleIn(1.5, BtMediaControl._pollKindleAvrcp)
+    end
+end
+
 -- ══════════════════════════════════════════════════════════════════════
 -- SENDING FEEDBACK TO BT DEVICE
 -- ══════════════════════════════════════════════════════════════════════
@@ -493,11 +618,19 @@ Kobo's mtkbtd exposes MediaTransport1 (not MediaPlayer1), so we update
 the transport State property.  Some headsets reflect this as a status
 indicator or voice prompt.
 
+On Kindle, advertise via btui UpdatePlayBackState so AirPods treat us as
+an AVRCP target (required for stem play/pause to generate events).
+
 @param status string  "playing", "paused", or "stopped"
 --]]
 function BtMediaControl.sendPlaybackStatus(status)
     if BtMediaControl._last_sent_status == status then return end
     BtMediaControl._last_sent_status = status
+
+    if Device.isKindle and Device:isKindle() then
+        BtMediaControl._kindleAdvertisePlaybackState(status)
+        return
+    end
 
     local transport_path = BtMediaControl._findMediaTransportPath()
     if not transport_path then

--- a/bugreport.lua
+++ b/bugreport.lua
@@ -616,6 +616,13 @@ local function collectAudioInfo(plugin, skip_intensive)
         end
         info.kindle_abk_gst_pids = shellCapture(
             "pgrep -af 'abk-progress|gst-launch-0.10|mixersink' 2>/dev/null | head -15", 3) or "none"
+        -- Input / AVRCP discovery for AirPods stem play-pause.
+        info.kindle_input_devices = shellCapture(
+            "cat /proc/bus/input/devices 2>/dev/null | head -120", 3) or "n/a"
+        info.kindle_input_event_nodes = shellCapture(
+            "ls -la /dev/input/ 2>/dev/null | head -40", 2) or "n/a"
+        info.kindle_btui = shellCapture(
+            "command -v btui 2>/dev/null; ls -la /usr/bin/btui 2>/dev/null", 2) or "not found"
         -- Full ALSA config: v0.1.5.24 showed dmix0 on hw:0,0 -- we need
         -- the complete config to see all defined PCMs and their routing.
         info.kindle_asound_conf_full = shellCapture("cat /etc/asound.conf 2>/dev/null", 5) or "not found"

--- a/bugreport.lua
+++ b/bugreport.lua
@@ -598,6 +598,24 @@ local function collectAudioInfo(plugin, skip_intensive)
         info.kindle_audiomgrd_output_connected = shellCapture("lipc-get-prop com.lab126.audiomgrd audioOutputConnected 2>/dev/null", 2) or "n/a"
         info.kindle_audiomgrd_current_output = shellCapture("lipc-get-prop com.lab126.audiomgrd audioCurrentOutput 2>/dev/null", 2) or "n/a"
         info.kindle_audiomgrd_volume = shellCapture("lipc-get-prop com.lab126.audiomgrd speakerVolume 2>/dev/null", 2) or "n/a"
+        -- AirPods Pro / Apple headset diagnostics (btfd hash lists + route).
+        -- Used to confirm A2DP is up when audio dies after a short blip.
+        info.kindle_btfd_list_connected = shellCapture(
+            "lipc-hash-prop com.lab126.btfd ListConnected 2>/dev/null | head -40", 3) or "n/a"
+        info.kindle_btfd_list_paired = shellCapture(
+            "lipc-hash-prop com.lab126.btfd ListPaired 2>/dev/null | head -40", 3) or "n/a"
+        local connected_dump = info.kindle_btfd_list_connected or ""
+        local apple_name = connected_dump:match('bd_name%s*=%s*"(.-)"')
+        info.kindle_apple_headset = "no"
+        if apple_name and apple_name:lower():find("airpods", 1, true) then
+            info.kindle_apple_headset = "airpods:" .. apple_name
+        elseif apple_name and apple_name:lower():find("beats", 1, true) then
+            info.kindle_apple_headset = "beats:" .. apple_name
+        elseif apple_name then
+            info.kindle_apple_headset = "other:" .. apple_name
+        end
+        info.kindle_abk_gst_pids = shellCapture(
+            "pgrep -af 'abk-progress|gst-launch-0.10|mixersink' 2>/dev/null | head -15", 3) or "none"
         -- Full ALSA config: v0.1.5.24 showed dmix0 on hw:0,0 -- we need
         -- the complete config to see all defined PCMs and their routing.
         info.kindle_asound_conf_full = shellCapture("cat /etc/asound.conf 2>/dev/null", 5) or "not found"

--- a/docs/AIRPODS_PRO3_KINDLE.md
+++ b/docs/AIRPODS_PRO3_KINDLE.md
@@ -19,9 +19,10 @@ same device with Bose QuietComfort Ultra Gen1 and later with AirPods Pro 3.
 | Continuous Storyteller / audiobook playback | Works |
 | Pause → wait → Play via Kindle UI / plugin controls | Works (v0.1.17.17 keepalive + resume path) |
 | Seek / skip while playing | Works (v0.1.17.18 bridges A2DP across seek-restart) |
-| Auto-advance to next SMIL/playlist chunk (~4–5 min) | Works (v0.1.17.18 keepalive across track gap) |
+| Auto-advance to next SMIL/playlist chunk (~4–5 min) | Works (v0.1.17.21: A2DP keepalive + soft stop; optional BT reconnect via menu) |
+| Manual ⏭/⏮ chapter (Storyteller SMIL chapter) | Works (same bridge; BT cycle only if setting enabled) |
 | Manual Disconnect → Connect from plugin BT menu | Restores audio if the A2DP route went stale |
-| **BT** button on full player overlay | Cycles A2DP + restarts at current position (shortcut) |
+| Overlay **BT** button | Removed (v0.1.17.22); use menu “Reconnect BT on track change” / BT settings |
 | Volume up/down via AirPods stem | Works (system / `audiomgrd` volume path) |
 | ANC on/off via stem long-press / gestures | Works on the headset (Apple BLE); no plugin involvement |
 | **Stem single-press Play/Pause** | **Does not work** (see Limitations) |

--- a/docs/AIRPODS_PRO3_KINDLE.md
+++ b/docs/AIRPODS_PRO3_KINDLE.md
@@ -1,0 +1,181 @@
+# AirPods Pro 3 on Kindle Paperwhite (11th gen)
+
+Field report for **audiobook.koplugin** Bluetooth playback with Apple AirPods Pro 3
+on a jailbroken **Kindle Paperwhite 11th generation** (PW11), running KOReader.
+
+Validated in August 2026 against plugin builds **v0.1.17.15–v0.1.17.17**
+(branch work that became PR [#52](https://github.com/stradichenko/audiobook.koplugin/pull/52)).
+
+Companion Storyteller EPUB3 Media Overlay work (separate PR) was tested on the
+same device with Bose QuietComfort Ultra Gen1 and later with AirPods Pro 3.
+
+---
+
+## Current status (what works)
+
+| Scenario | Result |
+|----------|--------|
+| First play after pairing / reconnect from plugin BT UI | Works (audio reaches AirPods) |
+| Continuous Storyteller / audiobook playback | Works |
+| Pause → wait → Play via Kindle UI / plugin controls | Works (v0.1.17.17 keepalive + resume path) |
+| Seek / skip while playing | Works |
+| Manual Disconnect → Connect from plugin BT menu | Restores audio if the A2DP route went stale |
+| Volume up/down via AirPods stem | Works (system / `audiomgrd` volume path) |
+| ANC on/off via stem long-press / gestures | Works on the headset (Apple BLE); no plugin involvement |
+| **Stem single-press Play/Pause** | **Does not work** (see Limitations) |
+
+Pipeline used on Kindle:
+
+```text
+ffmpeg → gst-launch-0.10 fdsrc → mixersink stream-type=Music
+       → audiomgrd → btfd / Bluedroid A2DP → AirPods Pro 3
+```
+
+---
+
+## Hardware / software under test
+
+- **E-reader:** Kindle Paperwhite 11th generation (jailbroken, KOReader)
+- **Headset:** AirPods Pro 3 (`bd_name` example: `AirPods Pro 3 de Juan - Find My`)
+- **Plugin:** audiobook.koplugin (Kindle backend `kindle-gst-play`)
+- **Sample content:** Storyteller EPUB3 Media Overlay (*Le Roi de fer*, and other night-generated readaloud EPUBs)
+- **Also validated earlier on same Kindle:** Bose QuietComfort Ultra Gen1 (Storyteller sync / highlight path)
+
+Bug reports used during diagnosis (device root, after repro):
+
+- `audiobook-bug-report-20260809-071033.txt` — initial “blip then silence”
+- `audiobook-bug-report-20260809-073727.txt` — pause/resume silence + stem
+- `audiobook-bug-report-20260809-080541.txt` — resume-restart with dead A2DP route
+- `audiobook-bug-report-20260809-083008.txt` — stem volume/ANC vs play/pause
+
+---
+
+## Problems we hit (and how they were fixed)
+
+### 1. Audio starts for ~1 s then permanent silence
+
+**Symptoms:** A2DP “connected”, sockets present, ffmpeg/gst still running or killed;
+listener hears a short blip then nothing.
+
+**Causes found in `crash.log` / bug reports:**
+
+- Redundant `seek-by-restart` immediately after play (killed a healthy pipeline)
+- Orphan-kill on PID-capture miss (`spawn-fallback`) murdering the just-started stream
+- Premature pipeline exit treated as EOS
+
+**Mitigations:** skip no-op seeks; recover PID via `pgrep`; longer AirPods `adelay`/`apad`;
+treat early exit as fail + one retry; Music-focus reclaim; A2DP watchdog.
+
+### 2. Pause then Play → silence (until manual BT reconnect)
+
+**Symptoms:** UI shows playing, position advances, no sound on AirPods.
+Manual Disconnect/Connect from the plugin BT menu restores audio.
+
+**Root cause:** Kindle `audiomgrd` suspends the A2DP datapath when the mixer goes
+idle. `SIGSTOP`/`SIGCONT` and even “resume-restart” of the content pipeline were
+not enough once the route was dead. Reconnect works because `BTManager:connect`
+does a **Disconnect/Connect cycle** that re-arms A2DP.
+
+**Mitigations (v0.1.17.17):**
+
+- On pause: halt content, start a **silence keepalive** on `mixersink` (same idea as TTS)
+- On resume: keep keepalive across the content restart gap; if
+  `audioOutputConnected` is still 0, **cycle BT** (Disconnect → Connect) then play
+- Watchdog: same cycle + restart when the route drops mid-play
+
+### 3. Stem Play/Pause does nothing
+
+**Symptoms:** Stem volume and ANC work; single-press does not pause/resume KOReader.
+
+**Finding:** `/proc/bus/input/devices` only exposes power key + touch (`bd71828-pwrkey`,
+`pt_mt`). No `(AVRCP)` / Consumer Control node. `btui` is absent on this firmware.
+`playermgr InPlayback` never toggles on stem press. `bt_media_control` can be on;
+there is simply **no event to receive**.
+
+See [Limitations](#limitations-airpods-stem-playpause) below.
+
+---
+
+## Limitations (AirPods stem Play/Pause)
+
+**AVRCP** (*Audio/Video Remote Control Profile*) is the Bluetooth profile that
+carries remote commands (Play, Pause, Next, …) from a headset to a player.
+
+On many Linux/BlueZ stacks, those commands appear as a virtual keyboard:
+
+```text
+/dev/input/eventN   name contains "(AVRCP)" or media keys
+```
+
+The plugin’s `btmediacontrol.lua` listens for that (and Kobo D-Bus MediaPlayer1).
+
+On **Kindle PW11 + Lab126 `btfd`/Bluedroid**:
+
+- There is **no AVRCP input device** for third-party players using `mixersink`
+- Volume still works via Absolute Volume / `audiomgrd` (`speakerVolume`)
+- ANC is handled inside Apple’s BLE stack on the buds
+- Stem **Play/Pause** requires the host to register as an AVRCP *target*; Amazon’s
+  Audible/TTS path may do that, but our `ffmpeg|gst|mixersink` path does not get
+  a Linux media-key device
+
+**Conclusion for this platform:** stem Play/Pause is a **platform gap**, not a
+missing checkbox in the plugin UI. Use on-screen controls or Kindle buttons.
+
+---
+
+## Pistes to push stem Play/Pause further
+
+These are research directions, not implemented:
+
+1. **`ace_bt` / `btmanagerd` / KindleBT** — register as an AVRCP target via Amazon’s
+   proprietary IPC (`/dev/aipc/…`), similar to [Sighery/kindlebt](https://github.com/Sighery/kindlebt).
+   Heavy native work; firmware-dependent.
+2. **`btui UpdatePlayBackState` / `UpdateMetaData`** — present on some Kindles as an
+   interactive test UI; **not found** on the PW11 under test (`kindle_btui: not found`).
+3. **LIPC event subscriptions** — watch for undocumented `btfd`/`playermgr` events
+   when the stem is pressed (none observed in our captures).
+4. **HCI / Bluedroid snoop** — confirm whether AVRCP pass-through frames are dropped
+   before userspace (Wireshark/Apple BT tooling on a PC is useful for protocol study only).
+
+**Kobo Libra Colour (Kaleido 3):** much more promising. That device uses `mtkbtd`
+(BlueZ-compatible). The plugin already has AVRCP evdev + D-Bus paths used with
+other headsets (e.g. Shokz). AirPods Pro 3 stem Play/Pause should be re-tested there;
+the infrastructure exists, unlike on Kindle `btfd`.
+
+---
+
+## Manual test checklist (PW11 + AirPods Pro 3)
+
+Performed and passing unless noted:
+
+- [x] Pair AirPods; connect from plugin Bluetooth UI; start Storyteller read-aloud
+- [x] Audio continues past the first 1–2 seconds (no permanent silence after blip)
+- [x] Pause (Kindle / UI) for several seconds → Play → audio returns on AirPods
+- [x] Longer pause (~2+ minutes) → Play → audio returns (keepalive held A2DP)
+- [x] Seek / chapter jump while playing
+- [x] Disconnect + Connect from plugin BT menu restores audio when route was stale
+- [x] Bug report fields: `kindle_apple_headset`, `kindle_btfd_list_connected`, gst PIDs
+- [x] Stem volume up/down works
+- [x] Stem ANC toggle works (headset-local)
+- [ ] Stem Play/Pause controls KOReader — **blocked** (no AVRCP device on this firmware)
+- [x] Regression context: Bose QC Ultra Gen1 previously OK for Storyteller sync on same Kindle
+
+---
+
+## Code touchpoints
+
+| Area | Files |
+|------|--------|
+| Kindle gst play / pause keepalive / BT cycle | `mediaengine.lua` |
+| Headset media buttons (evdev / Kindle stubs) | `btmediacontrol.lua`, `main.lua` |
+| Hard stop clears keepalive | `mediasync.lua` |
+| Diagnostics | `bugreport.lua` (`kindle_apple_headset`, input devices, `btui`) |
+
+Related platform overview: [PLATFORM_AUDIO.md](./PLATFORM_AUDIO.md) (Kindle `btfd` / `audiomgrd` section).
+
+---
+
+## Deploy note
+
+Copy the plugin tree to `koreader/plugins/audiobook.koplugin/` and **fully restart
+KOReader** after updates. Partial Lua reloads are not enough for MediaEngine changes.

--- a/docs/AIRPODS_PRO3_KINDLE.md
+++ b/docs/AIRPODS_PRO3_KINDLE.md
@@ -18,8 +18,10 @@ same device with Bose QuietComfort Ultra Gen1 and later with AirPods Pro 3.
 | First play after pairing / reconnect from plugin BT UI | Works (audio reaches AirPods) |
 | Continuous Storyteller / audiobook playback | Works |
 | Pause → wait → Play via Kindle UI / plugin controls | Works (v0.1.17.17 keepalive + resume path) |
-| Seek / skip while playing | Works |
+| Seek / skip while playing | Works (v0.1.17.18 bridges A2DP across seek-restart) |
+| Auto-advance to next SMIL/playlist chunk (~4–5 min) | Works (v0.1.17.18 keepalive across track gap) |
 | Manual Disconnect → Connect from plugin BT menu | Restores audio if the A2DP route went stale |
+| **BT** button on full player overlay | Cycles A2DP + restarts at current position (shortcut) |
 | Volume up/down via AirPods stem | Works (system / `audiomgrd` volume path) |
 | ANC on/off via stem long-press / gestures | Works on the headset (Apple BLE); no plugin involvement |
 | **Stem single-press Play/Pause** | **Does not work** (see Limitations) |

--- a/docs/PLATFORM_AUDIO.md
+++ b/docs/PLATFORM_AUDIO.md
@@ -242,7 +242,10 @@ devices.
 
 ## 4. Kindle
 
-**Confirmed device:** Kindle Basic 2022 (11th Gen) -- speakerless
+**Confirmed device:** Kindle Basic 2022 (11th Gen) -- speakerless  
+**Also field-tested:** Kindle Paperwhite 11th gen + Apple AirPods Pro 3 (see
+[AIRPODS_PRO3_KINDLE.md](./AIRPODS_PRO3_KINDLE.md) for playback fixes, pause
+keepalive, and AVRCP stem limitations).
 
 ### Bluetooth
 
@@ -260,6 +263,11 @@ devices.
 **NOTE:** Read and write properties may differ by name and type across Kindle
 generations (e.g., `BTstate` for reading vs `BTenable` for writing on the
 Basic 2022).
+
+**AVRCP / headset buttons:** Kindle `btfd` does **not** expose a Linux
+`(AVRCP)` input device for third-party `mixersink` players. AirPods stem
+volume/ANC can still work; stem Play/Pause does not reach the plugin.
+Kobo `mtkbtd` is different — see `btmediacontrol.lua` and the AirPods doc.
 
 ### Audio Pipeline
 

--- a/main.lua
+++ b/main.lua
@@ -551,6 +551,19 @@ function Audiobook:addToMainMenu(menu_items)
                         help_text = _("When enabled, play/pause/next/prev buttons on a Bluetooth headset or speaker will control playback. The connected device will also show playback status.\n\nNote: Kindle Paperwhite does not expose an AVRCP input device for AirPods stem presses (no btui / no media-key evdev). Stem play/pause is not available on this firmware; use the on-screen controls or Kindle buttons."),
                     },
                     {
+                        text = _("Reconnect BT on track change"),
+                        enabled_func = function()
+                            return Device.isKindle and Device:isKindle()
+                        end,
+                        checked_func = function()
+                            return self:getSetting("kindle_bt_reconnect_on_track", false)
+                        end,
+                        callback = function()
+                            self:toggleSetting("kindle_bt_reconnect_on_track", false)
+                        end,
+                        help_text = _("Kindle + AirPods: when enabled, each playlist/Storyteller audio-file boundary runs a Bluetooth Disconnect→Connect cycle before the next file starts (~5–10 s gap). Off by default; the plugin still keeps a silent A2DP keepalive across the gap. Turn this on only if audio goes silent at chapter/chunk transitions."),
+                    },
+                    {
                         text_func = function()
                             local val = self:getSetting("bt_disconnect_check", 30)
                             if val == 0 then

--- a/main.lua
+++ b/main.lua
@@ -548,7 +548,7 @@ function Audiobook:addToMainMenu(menu_items)
                                 BtMediaControl.stop()
                             end
                         end,
-                        help_text = _("When enabled, play/pause/next/prev buttons on a Bluetooth headset or speaker will control playback. The connected device will also show playback status."),
+                        help_text = _("When enabled, play/pause/next/prev buttons on a Bluetooth headset or speaker will control playback. The connected device will also show playback status.\n\nNote: Kindle Paperwhite does not expose an AVRCP input device for AirPods stem presses (no btui / no media-key evdev). Stem play/pause is not available on this firmware; use the on-screen controls or Kindle buttons."),
                     },
                     {
                         text_func = function()

--- a/main.lua
+++ b/main.lua
@@ -808,6 +808,17 @@ function Audiobook:addToMainMenu(menu_items)
                         help_text = _("When enabled (default), an aligned audiobook will automatically turn pages to keep the narration in view, and manually turning the page will seek narration to the new page. When disabled, pages do not auto-follow and manual turns do not seek audio; only the currently visible text is highlighted."),
                     },
                     {
+                        text = _("Keep status bars during read-aloud"),
+                        enabled_func = function() return (self.ui and self.ui.document) or false end,
+                        checked_func = function()
+                            return self:getSetting("keep_reader_status_bars", false)
+                        end,
+                        callback = function()
+                            self:toggleSetting("keep_reader_status_bars", false)
+                        end,
+                        help_text = _("When enabled, the minimized read-aloud mini player sits above KOReader’s bottom status bar / progress bar (alt status bar at the top is unchanged). The page always reflows so book text ends above the mini player — the player never covers readable text. When disabled (default), the mini player sits at the bottom of the screen (may cover the status bar) but text is still reflowed above it."),
+                    },
+                    {
                         text = _("Sleep timer"),
                         sub_item_table = {
                             {

--- a/main.lua
+++ b/main.lua
@@ -1602,11 +1602,7 @@ function Audiobook:_startSmilPlayback(doc_path, start_entry, allow_resume)
                 "start_time=", start_time)
         end
 
-        pcall(function()
-            if self:getSetting("bt_media_control", true) and BtMediaControl then
-                BtMediaControl.start(self)
-            end
-        end)
+        pcall(function() self:_ensureBtMediaControl() end)
 
         -- Cache parser/timing for page-follow and selection restarts.
         -- If we are switching to a different EPUB, drop the resolved-xpointer
@@ -1764,11 +1760,7 @@ function Audiobook:_playAudioFile(file_path, playlist_files)
         local slot = self._smil_by_file[file_path]
         self.media_sync:start(file_path, slot.timing, slot.chapters, nil,
             playlist_files or self.media_sync.playlist_files, file_path)
-        pcall(function()
-            if self:getSetting("bt_media_control", true) and BtMediaControl then
-                BtMediaControl.start(self)
-            end
-        end)
+        pcall(function() self:_ensureBtMediaControl() end)
         return
     end
 
@@ -2705,6 +2697,22 @@ function Audiobook:stopReadAlong()
     pcall(function() self.tts_engine:forceKillAll() end)
 end
 
+--- Ensure headset media buttons (AirPods stem) are listened for.
+-- On Kindle, auto-enable the setting: BlueZ AVRCP is absent and the stem
+-- only works if we advertise as an AVRCP target + scan for media input.
+function Audiobook:_ensureBtMediaControl()
+    if not BtMediaControl then return end
+    if Device.isKindle and Device:isKindle() then
+        if not self:getSetting("bt_media_control", true) then
+            self:setSetting("bt_media_control", true)
+            logger.warn("Audiobook: enabled bt_media_control for Kindle headset buttons")
+        end
+    end
+    if self:getSetting("bt_media_control", true) then
+        BtMediaControl.start(self)
+    end
+end
+
 function Audiobook:pauseReadAlong()
     if not self._init_ok then return end
     -- Pause media playback if active
@@ -2724,11 +2732,13 @@ function Audiobook:resumeReadAlong()
     if not self._init_ok then return end
     -- Resume media playback if active
     if self.media_sync and self.media_sync.state == "paused" then
+        pcall(function() self:_ensureBtMediaControl() end)
         pcall(function() self.media_sync:resume() end)
         pcall(function() BtMediaControl.sendPlaybackStatus("playing") end)
         return
     end
     if self.sync_controller then
+        pcall(function() self:_ensureBtMediaControl() end)
         pcall(function() self.sync_controller:resume() end)
         pcall(function() BtMediaControl.sendPlaybackStatus("playing") end)
     end
@@ -2831,9 +2841,19 @@ end
 
 function Audiobook:onMediaPlayPause()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() then
+    -- Prefer media_sync (Storyteller / audiobook) over TTS sync_controller.
+    local media_active = self.media_sync and self.media_sync.state ~= "stopped"
+    if media_active then
+        if self.media_sync.state == "playing" then
+            self:pauseReadAlong()
+        elseif self.media_sync.state == "paused" then
+            self:resumeReadAlong()
+        end
+        return true
+    end
+    if self.sync_controller and self.sync_controller:isPlaying() then
         self:pauseReadAlong()
-    elseif self.sync_controller:isPaused() then
+    elseif self.sync_controller and self.sync_controller:isPaused() then
         self:resumeReadAlong()
     end
     return true
@@ -2841,17 +2861,13 @@ end
 
 function Audiobook:onMediaPlay()
     if not self._init_ok then return true end
-    if self.sync_controller:isPaused() then
-        self:resumeReadAlong()
-    end
+    self:resumeReadAlong()
     return true
 end
 
 function Audiobook:onMediaPause()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() then
-        self:pauseReadAlong()
-    end
+    self:pauseReadAlong()
     return true
 end
 
@@ -2864,7 +2880,11 @@ end
 
 function Audiobook:onMediaNext()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() or self.sync_controller:isPaused() then
+    if self.media_sync and self.media_sync.state ~= "stopped" then
+        self.media_sync:nextChapter()
+        return true
+    end
+    if self.sync_controller and (self.sync_controller:isPlaying() or self.sync_controller:isPaused()) then
         self.sync_controller:nextSentence()
     end
     return true
@@ -2872,7 +2892,11 @@ end
 
 function Audiobook:onMediaPrev()
     if not self._init_ok then return true end
-    if self.sync_controller:isPlaying() or self.sync_controller:isPaused() then
+    if self.media_sync and self.media_sync.state ~= "stopped" then
+        self.media_sync:prevChapter()
+        return true
+    end
+    if self.sync_controller and (self.sync_controller:isPlaying() or self.sync_controller:isPaused()) then
         self.sync_controller:prevSentence()
     end
     return true

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -175,18 +175,51 @@ function MediaEngine:_startKindleA2dpKeepalive(reason)
     local pid_str = h and h:read("*a") or ""
     if h then h:close() end
     self._keepalive_pid = tonumber(pid_str:match("(%d+)"))
-    logger.warn("MediaEngine: Kindle A2DP keepalive started (", reason or "?",
+    self._keepalive_reason = reason or "?"
+    logger.warn("MediaEngine: Kindle A2DP keepalive started (", self._keepalive_reason,
         ") PID=", self._keepalive_pid)
 end
 
-function MediaEngine:_stopKindleA2dpKeepalive()
+function MediaEngine:_stopKindleA2dpKeepalive(only_if_reason)
+    if only_if_reason and self._keepalive_reason ~= only_if_reason then
+        return
+    end
     local pid = self._keepalive_pid
     self._keepalive_pid = nil
+    self._keepalive_reason = nil
     if not pid then return end
     os.execute("kill -9 " .. tostring(pid) .. " 2>/dev/null")
     -- Also match the distinctive log path in case $! was a wrapper shell.
     os.execute("pkill -9 -f 'abk-keepalive' 2>/dev/null")
     logger.warn("MediaEngine: Kindle A2DP keepalive stopped PID=", pid)
+end
+
+--- Public: cycle BT A2DP and restart content at the current position.
+--- Used by the player "Fix audio" button when AirPods go silent mid-play.
+function MediaEngine:fixKindleA2dpAudio()
+    if not self:_isKindle() then return false end
+    if not self.current_path then return false end
+    local pos = 0
+    pcall(function() pos = self:getPosition() or 0 end)
+    if pos <= 0 then pos = self._seek_offset or 0 end
+    local complete = self._on_complete
+    local fail = self._on_fail
+    local gen = self.play_generation
+    self._seek_offset = math.max(0, pos)
+    logger.warn("MediaEngine: fixKindleA2dpAudio at", self._seek_offset)
+    self:_startKindleA2dpKeepalive("fix-audio")
+    self:_cycleKindleA2dpRoute(function(ok)
+        if self.play_generation ~= gen and not self.is_playing then
+            -- superseded
+        end
+        logger.warn("MediaEngine: fixKindleA2dpAudio route ok=", ok and "yes" or "no")
+        self.is_paused = false
+        self:play(complete, fail)
+        UIManager:scheduleIn(1.5, function()
+            self:_stopKindleA2dpKeepalive("fix-audio")
+        end)
+    end)
+    return true
 end
 
 --- Disconnect/Connect cycle that re-arms A2DP (same as BTManager:connect).
@@ -958,18 +991,16 @@ function MediaEngine:play(on_complete, on_fail)
         return false
     end
 
-    -- Defensive: on Kindle the mixersink can hold a dying stream across a
-    -- stop/play cycle and mix it with the new one, producing an echo/loop.
-    -- Nuke any orphan pipelines before stop() bumps the generation, then
-    -- stop() will also run the same cleanup as a fallback.
-    -- If a pause-keepalive is holding A2DP open, only kill content pipelines
-    -- so the datapath stays up across the resume gap.
-    if self:_isKindle() then
-        if self._keepalive_pid then
-            self:_killOrphanKindleGstPipelines("play-preflight", 100000, { content_only = true })
-        else
-            self:_killOrphanKindleGstPipelines("play-preflight", 300000)
+    -- Kindle A2DP (AirPods): any stop→play gap (seek, track advance, resume)
+    -- lets audiomgrd suspend the datapath.  Park silence first so orphan-kill
+    -- never leaves the mixer empty.
+    if self:_isKindle() and self:_kindleNeedsPipelineRestartOnResume() then
+        if not self._keepalive_pid then
+            self:_startKindleA2dpKeepalive("play-bridge")
         end
+        self:_killOrphanKindleGstPipelines("play-preflight", 100000, { content_only = true })
+    elseif self:_isKindle() then
+        self:_killOrphanKindleGstPipelines("play-preflight", 300000)
     end
 
     self:stop()
@@ -1601,6 +1632,17 @@ function MediaEngine:_playSystemGstLaunchFfmpeg(gen)
         { name = "kindle-gst", setsid = true, exec = false, quiet = true })
     if ok then
         self:_startA2dpWatchdog(gen)
+        -- Drop transitional keepalive once content is attached (not pause keepalive).
+        UIManager:scheduleIn(1.5, function()
+            if self.play_generation ~= gen then return end
+            if not self.is_playing or self.is_paused then return end
+            local reason = self._keepalive_reason
+            if reason == "play-bridge" or reason == "seek-bridge"
+                or reason == "track-advance" or reason == "fix-audio"
+                or reason == "route-recovery" then
+                self:_stopKindleA2dpKeepalive(reason)
+            end
+        end)
     end
     return ok
 end
@@ -2743,6 +2785,10 @@ function MediaEngine:seek(seconds, mode)
         self._play_start_time = UIManager:getTime()
         self._total_pause_ms = 0
         self._pause_start_time = nil
+        -- Bridge A2DP across the stop→play gap (AirPods go silent otherwise).
+        if was_playing and self:_kindleNeedsPipelineRestartOnResume() then
+            self:_startKindleA2dpKeepalive("seek-bridge")
+        end
         self:stop()
         -- Capture the generation AFTER stop() (stop bumps it).  The scheduled
         -- restart fires unless something else supersedes it in the 0.5 s gap
@@ -2759,7 +2805,14 @@ function MediaEngine:seek(seconds, mode)
                     logger.dbg("MediaEngine: seek restart cancelled (generation changed)")
                     return
                 end
-                self:play(saved_on_complete, saved_on_fail)
+                if self:_kindleNeedsPipelineRestartOnResume() then
+                    self:_ensureKindleA2dpRoute(function()
+                        if self.play_generation ~= restart_gen then return end
+                        self:play(saved_on_complete, saved_on_fail)
+                    end)
+                else
+                    self:play(saved_on_complete, saved_on_fail)
+                end
             end)
         else
             self.is_playing = true

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -91,10 +91,47 @@ end
 -- Every setFocus makes audiomgrd re-ramp gain to its stored level, which
 -- resets the headset volume on each call -- so seeks and track switches
 -- must not re-issue it.  New streams inherit focus from audiomgrd's cache.
-function MediaEngine._takeMusicFocusOnce()
-    if MediaEngine._focus_taken then return end
+-- Exception: Apple AirPods often drop the A2DP audio session after a short
+-- blip; forcing Music focus again on recovery is required to resume sound.
+function MediaEngine._takeMusicFocusOnce(force)
+    if MediaEngine._focus_taken and not force then return end
     os.execute("lipc-set-prop com.lab126.audiomgrd setFocus 'Music' 2>/dev/null")
     MediaEngine._focus_taken = true
+end
+
+function MediaEngine._clearMusicFocusFlag()
+    MediaEngine._focus_taken = false
+end
+
+--- Best-effort connected headset name from Kindle btfd (for AirPods heuristics).
+function MediaEngine:_kindleConnectedHeadsetName()
+    if not self:_isKindle() then return nil end
+    local h = io.popen("lipc-hash-prop com.lab126.btfd ListConnected 2>/dev/null")
+    if not h then return nil end
+    local out = h:read("*a") or ""
+    h:close()
+    -- Prefer the first non-empty bd_name.
+    for name in out:gmatch('bd_name%s*=%s*"(.-)"') do
+        if name ~= "" then return name end
+    end
+    return nil
+end
+
+function MediaEngine:_isAppleAirPodsHeadset()
+    local name = self:_kindleConnectedHeadsetName()
+    if not name then return false end
+    name = name:lower()
+    return name:find("airpods", 1, true) ~= nil
+        or name:find("beats", 1, true) ~= nil
+end
+
+function MediaEngine:_kindleA2dpRouteUp()
+    if not self:_isKindle() then return true end
+    local h = io.popen("lipc-get-prop com.lab126.audiomgrd audioOutputConnected 2>/dev/null")
+    if not h then return false end
+    local v = h:read("*a") or ""
+    h:close()
+    return v:match("^%s*1") ~= nil
 end
 
 --[[--
@@ -889,16 +926,27 @@ function MediaEngine:_spawnTracked(cmd, gen, opts)
             os.remove(pid_file)
             self:_startPositionPoller(gen)
             self:_startCompletionWatcher(gen)
-        elseif attempt < 3 then
-            UIManager:scheduleIn(0.2, function()
+        elseif attempt < 5 then
+            -- Kindle + AirPods: PID file can lag >0.3s while A2DP renegotiates.
+            -- Retry longer before giving up — never orphan-kill here: that was
+            -- murdering the just-started stream (brief sound, then silence).
+            UIManager:scheduleIn(0.25, function()
                 try_capture_pid(attempt + 1)
             end)
         else
             logger.warn("MediaEngine: " .. name .. " PID capture failed after retries")
-            -- Untracked Kindle gst pipelines are exactly what causes the
-            -- echo/loop; kill them now before they overlap the next seek.
+            -- Last resort: recover PID from the abk-progress ffmpeg cmdline
+            -- without killing anything.
             if name == "kindle-gst" and self:_isKindle() then
-                self:_killOrphanKindleGstPipelines("spawn-fallback", 300000)
+                local ph = io.popen("pgrep -f 'abk-progress-" .. tostring(gen) .. "' 2>/dev/null")
+                if ph then
+                    local recovered = tonumber((ph:read("*l") or ""):match("%d+"))
+                    ph:close()
+                    if recovered then
+                        self.audio_pid = recovered
+                        logger.warn("MediaEngine: recovered kindle-gst PID via pgrep =", recovered)
+                    end
+                end
             end
             os.remove(pid_file)
             self:_startPositionPoller(gen)
@@ -1281,7 +1329,16 @@ function MediaEngine:_playSystemGstLaunch(gen)
     -- (pause/seek), then take audio focus before the stream attaches.
     os.execute("for f in /dev/shm/mstream*; do p=${f#/dev/shm/mstream}; p=${p%%_*};"
         .. " [ -d /proc/$p ] || rm -f \"$f\"; done 2>/dev/null")
-    MediaEngine._takeMusicFocusOnce()
+    local apple = self:_isAppleAirPodsHeadset()
+    if apple and not self:_kindleA2dpRouteUp() then
+        MediaEngine._clearMusicFocusFlag()
+        MediaEngine._takeMusicFocusOnce(true)
+    else
+        MediaEngine._takeMusicFocusOnce()
+    end
+    if apple then
+        self.position_latency_s = 2.2
+    end
 
     -- Nuke any previous audiobook gst-launch-0.10 pipeline before attaching
     -- a new stream to mixersink.  If the old pipeline is still draining its
@@ -1297,9 +1354,14 @@ function MediaEngine:_playSystemGstLaunch(gen)
         .. " ! mixersink stream-type=Music sync=true",
         raw_file:gsub("'", "'\\''"), caps)
     logger.warn("MediaEngine: system gst-launch gen=", gen,
-        "rate=", rate, "ch=", channels, "seek_offset=", self._seek_offset or 0)
+        "rate=", rate, "ch=", channels, "seek_offset=", self._seek_offset or 0,
+        "apple_airpods=", apple and "yes" or "no")
 
-    return self:_spawnTracked(cmd, gen, { name = "kindle-gst", quiet = true })
+    local ok = self:_spawnTracked(cmd, gen, { name = "kindle-gst", quiet = true })
+    if ok then
+        self:_startA2dpWatchdog(gen)
+    end
+    return ok
 end
 
 --[[--
@@ -1332,7 +1394,15 @@ function MediaEngine:_playSystemGstLaunchFfmpeg(gen)
     self:_killOrphanKindleGstPipelines("kindle-gst-ffmpeg", 150000)
 
     -- Take focus after the old pipeline has had a moment to tear down.
-    MediaEngine._takeMusicFocusOnce()
+    -- AirPods: if the A2DP route is down, force a fresh Music focus so
+    -- audiomgrd re-binds the headset (once-per-session is not enough).
+    local apple = self:_isAppleAirPodsHeadset()
+    if apple and not self:_kindleA2dpRouteUp() then
+        MediaEngine._clearMusicFocusFlag()
+        MediaEngine._takeMusicFocusOnce(true)
+    else
+        MediaEngine._takeMusicFocusOnce()
+    end
 
     local seek = self._seek_offset or 0
 
@@ -1347,40 +1417,45 @@ function MediaEngine:_playSystemGstLaunchFfmpeg(gen)
     os.remove(progress_file)
     self._progress_file = progress_file
     self._use_progress_position = true
-    -- adelay prepends 0.5 s of silence inside the decoded stream, so out_time
-    -- is 0.5 s larger than the real content time; getPosition() subtracts it.
-    self._progress_adelay_s = 0.5
 
-    -- adelay=500:all=1: lead-in silence absorbing the A2DP datapath resume
-    -- (which otherwise swallows the start); apad: tail silence covering
-    -- the ring/BT buffers at EOS (which otherwise clip the end).
+    -- adelay lead-in absorbs A2DP datapath resume (otherwise swallows start);
+    -- apad covers ring/BT buffers at EOS.  AirPods Pro need a longer lead-in
+    -- before the AAC/SBC sink is ready to accept PCM.
+    local adelay_ms = apple and 900 or 500
+    local apad_s = apple and 1.5 or 1.0
+    -- adelay prepends silence inside the decoded stream; getPosition() subtracts it.
+    self._progress_adelay_s = adelay_ms / 1000
+
     -- :all=1 is required because the input may be stereo: without it adelay
     -- would delay only channel 0 and -ac 1 would mix delayed left with
     -- undelayed right, producing a persistent echo.
     local pipeline = string.format(
         "%s -loglevel error -progress '%s' -nostats -ss %.3f -i '%s'"
         .. " -f s16le -ar 22050 -ac 1"
-        .. " -af adelay=500:all=1%s,apad=pad_dur=1 - 2>/dev/null"
+        .. " -af adelay=%d:all=1%s,apad=pad_dur=%.1f - 2>/dev/null"
         .. " | gst-launch-0.10 fdsrc"
         .. " ! 'audio/x-raw-int,rate=22050,channels=1,width=16,depth=16,signed=true,endianness=1234'"
         .. " ! mixersink stream-type=Music sync=true",
         ffmpeg:gsub("'", "'\\''"), progress_file:gsub("'", "'\\''"), seek,
-        self.current_path:gsub("'", "'\\''"), self:_volumeFilterPart())
+        self.current_path:gsub("'", "'\\''"), adelay_ms, self:_volumeFilterPart(), apad_s)
     -- out_time is the PRODUCER side: it leads what the listener hears by the
     -- whole downstream buffer -- OS pipe (~1.5 s when full) + gst/mixersink
-    -- ring (~0.9 s) + BT chain (~0.3 s) ~= 2.7 s.  The sync loop subtracts
-    -- this so highlights match the audible audio.  Single stable constant
-    -- now (no variable startup mixed in); tune here if needed, the user's
-    -- live nudge handles any residual.
-    self.position_latency_s = 2.7
+    -- ring (~0.9 s) + BT chain (~0.3 s) ~= 2.7 s.  AirPods buffer a bit more.
+    self.position_latency_s = apple and 3.2 or 2.7
     logger.warn("MediaEngine: system gst-launch (ffmpeg stream) gen=", gen,
-        "seek_offset=", seek, "progress=", progress_file)
+        "seek_offset=", seek, "progress=", progress_file,
+        "apple_airpods=", apple and "yes" or "no",
+        "adelay_ms=", adelay_ms)
 
     -- setsid: the wrapper shell becomes a process-group leader so stop()'s
     -- kill(-pid) takes down ffmpeg AND gst-launch; without it the pipeline
     -- would be orphaned and keep playing.  exec=false: it's a pipeline.
-    return self:_spawnTracked(pipeline, gen,
+    local ok = self:_spawnTracked(pipeline, gen,
         { name = "kindle-gst", setsid = true, exec = false, quiet = true })
+    if ok then
+        self:_startA2dpWatchdog(gen)
+    end
+    return ok
 end
 
 -- ---------------------------------------------------------------------------
@@ -1965,6 +2040,50 @@ function MediaEngine:_startPositionPoller(gen)
     self._position_timer = UIManager:scheduleIn(1.0, poll)
 end
 
+--- Kindle A2DP watchdog: if audiomgrd drops the output route mid-play
+--- (common with AirPods Pro renegotiating AAC), re-take Music focus and
+--- soft-restart once at the current position.
+function MediaEngine:_startA2dpWatchdog(gen)
+    if not self:_isKindle() then return end
+    if self._a2dp_watchdog_gen == gen then return end
+    self._a2dp_watchdog_gen = gen
+    local misses = 0
+    local function tick()
+        if self.play_generation ~= gen then return end
+        if not self.is_playing or self.is_paused then return end
+        if self:_kindleA2dpRouteUp() then
+            misses = 0
+            -- Healthy play lasting a few ticks clears one-shot recovery flags.
+            self._a2dp_auto_retry_done = nil
+            self._a2dp_route_restart_done = nil
+        else
+            misses = misses + 1
+            logger.warn("MediaEngine: A2DP route down (miss=", misses, ")")
+            if misses >= 2 then
+                MediaEngine._clearMusicFocusFlag()
+                MediaEngine._takeMusicFocusOnce(true)
+                if self:_isAppleAirPodsHeadset() and not self._a2dp_route_restart_done then
+                    self._a2dp_route_restart_done = true
+                    local pos = 0
+                    pcall(function() pos = self:getPosition() or 0 end)
+                    local complete_cb = self._on_complete
+                    local fail_cb = self._on_fail
+                    self._seek_offset = math.max(0, pos)
+                    logger.warn("MediaEngine: A2DP route recovery restart at", self._seek_offset)
+                    UIManager:scheduleIn(0.4, function()
+                        if self.play_generation ~= gen then return end
+                        self:play(complete_cb, fail_cb)
+                    end)
+                    return
+                end
+                misses = 0
+            end
+        end
+        UIManager:scheduleIn(1.5, tick)
+    end
+    UIManager:scheduleIn(2.0, tick)
+end
+
 function MediaEngine:_startCompletionWatcher(gen)
     -- Watch for process exit via PID polling
     local function check()
@@ -1975,10 +2094,58 @@ function MediaEngine:_startCompletionWatcher(gen)
         if self.audio_pid then
             local h = io.open("/proc/" .. self.audio_pid .. "/status", "r")
             if not h then
-                -- Process exited
+                -- Process exited.  Distinguish EOS from a premature A2DP drop
+                -- (AirPods Pro often kill the stream after a short blip).
+                local pos = 0
+                pcall(function() pos = self:getPosition() or 0 end)
+                local dur = tonumber(self.current_duration) or 0
+                -- Avoid false positives on short SMIL clips (1–3 s): only treat
+                -- as premature when clearly far from natural EOS.
+                local premature = false
+                if dur > 4 then
+                    premature = pos < (dur - 1.5)
+                elseif dur > 0 then
+                    premature = pos < (dur * 0.45)
+                else
+                    premature = pos < 1.0
+                end
+
                 self.is_playing = false
                 self.is_paused = false
                 self.audio_pid = nil
+
+                if premature and self:_isKindle() then
+                    logger.warn("MediaEngine: premature pipeline exit at", pos,
+                        "dur=", dur, "— treating as fail (A2DP recovery)")
+                    MediaEngine._clearMusicFocusFlag()
+                    MediaEngine._takeMusicFocusOnce(true)
+                    local fail_cb = self._on_fail
+                    local complete_cb = self._on_complete
+                    self._on_fail = nil
+                    self._on_complete = nil
+                    -- One automatic restart for Apple headsets / Kindle GST.
+                    if not self._a2dp_auto_retry_done
+                        and (self:_isAppleAirPodsHeadset()
+                            or self.backend == self.BACKENDS.KINDLE_GST_PLAY) then
+                        self._a2dp_auto_retry_done = true
+                        self._seek_offset = math.max(0, pos)
+                        UIManager:scheduleIn(0.6, function()
+                            if self.play_generation ~= gen then return end
+                            logger.warn("MediaEngine: A2DP auto-retry at", self._seek_offset)
+                            self:play(complete_cb, fail_cb)
+                        end)
+                        return
+                    end
+                    if fail_cb then
+                        fail_cb("premature pipeline exit")
+                    elseif complete_cb then
+                        -- No fail handler: avoid advancing SMIL as if EOS.
+                        logger.warn("MediaEngine: premature exit, no on_fail; not completing")
+                    end
+                    return
+                end
+
+                self._a2dp_auto_retry_done = nil
                 if self._on_complete then
                     local cb = self._on_complete
                     self._on_complete = nil
@@ -2281,6 +2448,33 @@ function MediaEngine:seek(seconds, mode)
             target = self:getPosition() + seconds
         end
         target = math.max(0, target)
+
+        -- Kindle A2DP (esp. AirPods): a no-op seek-by-restart right after play
+        -- tears down a healthy pipeline → brief sound, then silence.
+        -- Skip when we are already at/near the requested offset.
+        do
+            local current = self:getPosition() or 0
+            local started_at = self._seek_offset or 0
+            local near_current = math.abs(current - target) < 0.6
+            local near_start = math.abs(started_at - target) < 0.25
+            local just_started = false
+            if self._play_start_time then
+                local ok_ms, age_ms = pcall(function()
+                    return time.to_ms(UIManager:getTime() - self._play_start_time)
+                end)
+                if ok_ms and type(age_ms) == "number" then
+                    just_started = age_ms < 2500
+                elseif near_start and was_playing then
+                    just_started = true
+                end
+            end
+            if was_playing and (near_current or (near_start and just_started)) then
+                logger.warn("MediaEngine: skip no-op seek-by-restart",
+                    "req=", seconds, "target=", target,
+                    "current=", current, "seek_offset=", started_at)
+                return true
+            end
+        end
 
         if self._persistent_pipeline_active then
             logger.warn("MediaEngine: persistent-pipeline seek mode=", mode,

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -136,11 +136,25 @@ end
 
 function MediaEngine:_kindleConnectedHeadsetMac()
     if not self:_isKindle() then return nil end
-    local h = io.popen("lipc-hash-prop com.lab126.btfd ListConnected 2>/dev/null")
-    if not h then return nil end
-    local out = h:read("*a") or ""
-    h:close()
-    return out:match('bd_address%s*=%s*"([%x:]+)"')
+    -- Prefer ListConnected; fall back to ListPaired when A2DP is stale and
+    -- the headset no longer appears in the connected list (common after
+    -- audiomgrd drops the idle AirPods session).  Finally reuse the last
+    -- MAC we successfully saw this session — cycle was skipping with
+    -- "no connected MAC" even though AirPods were still paired.
+    for _, prop in ipairs({ "ListConnected", "ListPaired" }) do
+        local h = io.popen("lipc-hash-prop com.lab126.btfd " .. prop .. " 2>/dev/null")
+        if h then
+            local out = h:read("*a") or ""
+            h:close()
+            -- Kindle prints "34:0E:22:..." — accept hex + colon only.
+            local mac = out:match('bd_address%s*=%s*"([%x:]+)"')
+            if mac and #mac >= 11 then
+                self._kindle_last_headset_mac = mac
+                return mac
+            end
+        end
+    end
+    return self._kindle_last_headset_mac
 end
 
 --- Kindle A2DP (esp. AirPods): SIGSTOP/SIGCONT leaves the pipeline frozen while
@@ -194,11 +208,44 @@ function MediaEngine:_stopKindleA2dpKeepalive(only_if_reason)
     logger.warn("MediaEngine: Kindle A2DP keepalive stopped PID=", pid)
 end
 
+--- Bridge A2DP across a Storyteller/playlist file boundary.
+--- Always starts silence keepalive. Optionally Disconnect→Connect the headset
+--- when opts.cycle_bt is true (plugin setting kindle_bt_reconnect_on_track).
+--- @param callback function|nil  callback(ok)
+--- @param opts table|nil  { cycle_bt = boolean }
+function MediaEngine:prepareKindleTrackAdvance(callback, opts)
+    opts = opts or {}
+    if not self:_isKindle() then
+        if callback then callback(true) end
+        return
+    end
+    self:_startKindleA2dpKeepalive("track-advance")
+    if not opts.cycle_bt then
+        logger.warn("MediaEngine: prepareKindleTrackAdvance — keepalive only (BT cycle off)")
+        if callback then callback(true) end
+        return
+    end
+    logger.warn("MediaEngine: prepareKindleTrackAdvance — cycling BT before next file")
+    self:_cycleKindleA2dpRoute(function(ok)
+        logger.warn("MediaEngine: track-advance A2DP cycle ok=", ok and "yes" or "no")
+        -- Keep keepalive running across the subsequent MediaSync:start/play gap.
+        if callback then callback(ok) end
+    end)
+end
+
 --- Public: cycle BT A2DP and restart content at the current position.
 --- Used by the player "Fix audio" button when AirPods go silent mid-play.
-function MediaEngine:fixKindleA2dpAudio()
-    if not self:_isKindle() then return false end
-    if not self.current_path then return false end
+--- @param on_done function|nil  optional callback(ok, reason)
+---   reason: "started" | "no_path" | "no_mac" | "route_up" | "route_down"
+function MediaEngine:fixKindleA2dpAudio(on_done)
+    if not self:_isKindle() then
+        if on_done then on_done(false, "not_kindle") end
+        return false
+    end
+    if not self.current_path then
+        if on_done then on_done(false, "no_path") end
+        return false
+    end
     local pos = 0
     pcall(function() pos = self:getPosition() or 0 end)
     if pos <= 0 then pos = self._seek_offset or 0 end
@@ -207,6 +254,12 @@ function MediaEngine:fixKindleA2dpAudio()
     local gen = self.play_generation
     self._seek_offset = math.max(0, pos)
     logger.warn("MediaEngine: fixKindleA2dpAudio at", self._seek_offset)
+    local mac = self:_kindleConnectedHeadsetMac()
+    if not mac then
+        logger.warn("MediaEngine: fixKindleA2dpAudio aborted (no headset MAC)")
+        if on_done then on_done(false, "no_mac") end
+        return false
+    end
     self:_startKindleA2dpKeepalive("fix-audio")
     self:_cycleKindleA2dpRoute(function(ok)
         if self.play_generation ~= gen and not self.is_playing then
@@ -218,6 +271,7 @@ function MediaEngine:fixKindleA2dpAudio()
         UIManager:scheduleIn(1.5, function()
             self:_stopKindleA2dpKeepalive("fix-audio")
         end)
+        if on_done then on_done(ok, ok and "route_up" or "route_down") end
     end)
     return true
 end

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -134,6 +134,15 @@ function MediaEngine:_kindleA2dpRouteUp()
     return v:match("^%s*1") ~= nil
 end
 
+function MediaEngine:_kindleConnectedHeadsetMac()
+    if not self:_isKindle() then return nil end
+    local h = io.popen("lipc-hash-prop com.lab126.btfd ListConnected 2>/dev/null")
+    if not h then return nil end
+    local out = h:read("*a") or ""
+    h:close()
+    return out:match('bd_address%s*=%s*"([%x:]+)"')
+end
+
 --- Kindle A2DP (esp. AirPods): SIGSTOP/SIGCONT leaves the pipeline frozen while
 --- audiomgrd drops the idle headset session — resume must re-attach Music focus
 --- and restart the gst pipeline at the pause position.
@@ -143,6 +152,93 @@ function MediaEngine:_kindleNeedsPipelineRestartOnResume()
         or self.backend == self.BACKENDS.GST_PLAY
         or self.backend == self.BACKENDS.GST_PIPELINE
         or self.backend == self.BACKENDS.FFMPEG_PIPE
+end
+
+--- Silence stream that keeps audiomgrd's A2DP datapath awake while paused
+--- (same trick as TTSEngine:_ensureKindleKeepalive). Without this, pause
+--- suspends A2DP and resume-restart plays into a dead route until the user
+--- manually Disconnect/Connect the headset.
+function MediaEngine:_startKindleA2dpKeepalive(reason)
+    if not self:_isKindle() then return end
+    if self._keepalive_pid then
+        local f = io.open("/proc/" .. self._keepalive_pid .. "/status", "r")
+        if f then f:close(); return end
+        self._keepalive_pid = nil
+    end
+    MediaEngine._takeMusicFocusOnce(true)
+    -- Tag the cmdline with abk-keepalive so content-only cleanup can spare it.
+    local h = io.popen(
+        "gst-launch-0.10 filesrc location=/dev/zero"
+        .. " ! 'audio/x-raw-int,rate=22050,channels=1,width=16,depth=16,signed=true,endianness=1234'"
+        .. " ! mixersink stream-type=Music sync=true"
+        .. " >/tmp/abk-keepalive.log 2>&1 & echo $!")
+    local pid_str = h and h:read("*a") or ""
+    if h then h:close() end
+    self._keepalive_pid = tonumber(pid_str:match("(%d+)"))
+    logger.warn("MediaEngine: Kindle A2DP keepalive started (", reason or "?",
+        ") PID=", self._keepalive_pid)
+end
+
+function MediaEngine:_stopKindleA2dpKeepalive()
+    local pid = self._keepalive_pid
+    self._keepalive_pid = nil
+    if not pid then return end
+    os.execute("kill -9 " .. tostring(pid) .. " 2>/dev/null")
+    -- Also match the distinctive log path in case $! was a wrapper shell.
+    os.execute("pkill -9 -f 'abk-keepalive' 2>/dev/null")
+    logger.warn("MediaEngine: Kindle A2DP keepalive stopped PID=", pid)
+end
+
+--- Disconnect/Connect cycle that re-arms A2DP (same as BTManager:connect).
+--- Non-blocking: invokes callback(ok) when done.
+function MediaEngine:_cycleKindleA2dpRoute(callback)
+    local mac = self:_kindleConnectedHeadsetMac()
+    if not mac then
+        logger.warn("MediaEngine: A2DP cycle skipped (no connected MAC)")
+        if callback then callback(false) end
+        return
+    end
+    logger.warn("MediaEngine: cycling Kindle A2DP for", mac)
+    os.execute(string.format(
+        "lipc-set-prop com.lab126.btfd Disconnect '%s' 2>/dev/null", mac))
+    UIManager:scheduleIn(2.5, function()
+        os.execute(string.format(
+            "lipc-set-prop com.lab126.btfd Connect '%s' 2>/dev/null", mac))
+        local attempts = 0
+        local function wait_route()
+            attempts = attempts + 1
+            local up = self:_kindleA2dpRouteUp()
+            if up or attempts >= 10 then
+                MediaEngine._clearMusicFocusFlag()
+                MediaEngine._takeMusicFocusOnce(true)
+                logger.warn("MediaEngine: A2DP cycle done up=", up and "yes" or "no",
+                    "attempts=", attempts)
+                if callback then callback(up) end
+                return
+            end
+            UIManager:scheduleIn(1.0, wait_route)
+        end
+        UIManager:scheduleIn(1.0, wait_route)
+    end)
+end
+
+--- Ensure A2DP is up before resume/play. Uses keepalive/focus first, cycles BT if needed.
+function MediaEngine:_ensureKindleA2dpRoute(callback)
+    MediaEngine._clearMusicFocusFlag()
+    MediaEngine._takeMusicFocusOnce(true)
+    if self:_kindleA2dpRouteUp() then
+        if callback then callback(true) end
+        return
+    end
+    -- Keepalive may still be attaching; brief retry before a full BT cycle.
+    UIManager:scheduleIn(0.8, function()
+        if self:_kindleA2dpRouteUp() then
+            MediaEngine._takeMusicFocusOnce(true)
+            if callback then callback(true) end
+            return
+        end
+        self:_cycleKindleA2dpRoute(callback)
+    end)
 end
 
 --- Halt the Kindle ffmpeg|gst pipeline without clearing pause/callbacks.
@@ -161,7 +257,8 @@ function MediaEngine:_haltKindlePipelineForPause(reason)
         pcall(function() ffi.C.kill(pid, 9) end)
     end
     if self:_isKindle() then
-        self:_killOrphanKindleGstPipelines(reason or "pause-halt", 150000)
+        -- Kill content pipelines only; keepalive is started right after.
+        self:_killOrphanKindleGstPipelines(reason or "pause-halt", 120000, { content_only = true })
     end
     if self._progress_file then
         os.remove(self._progress_file)
@@ -865,8 +962,14 @@ function MediaEngine:play(on_complete, on_fail)
     -- stop/play cycle and mix it with the new one, producing an echo/loop.
     -- Nuke any orphan pipelines before stop() bumps the generation, then
     -- stop() will also run the same cleanup as a fallback.
+    -- If a pause-keepalive is holding A2DP open, only kill content pipelines
+    -- so the datapath stays up across the resume gap.
     if self:_isKindle() then
-        self:_killOrphanKindleGstPipelines("play-preflight", 300000)
+        if self._keepalive_pid then
+            self:_killOrphanKindleGstPipelines("play-preflight", 100000, { content_only = true })
+        else
+            self:_killOrphanKindleGstPipelines("play-preflight", 300000)
+        end
     end
 
     self:stop()
@@ -1236,24 +1339,28 @@ containing "abk-progress", and every audiobook pipeline ends in
 prevents two streams from mixing in mixersink, which the user hears as an
 echo/loop.
 --]]
-function MediaEngine:_killOrphanKindleGstPipelines(name, wait_us)
+function MediaEngine:_killOrphanKindleGstPipelines(name, wait_us, opts)
     name = name or "kindle-gst"
-    logger.warn("MediaEngine: killing orphan Kindle audiobook pipelines (", name, ")")
+    opts = opts or {}
+    local content_only = opts.content_only
+    logger.warn("MediaEngine: killing orphan Kindle audiobook pipelines (", name,
+        content_only and ", content_only" or "", ")")
     -- ffmpeg side of the ffmpeg|gst-launch pipeline.  Use multiple patterns
     -- because busybox pkill on some firmwares matches the full command line
     -- differently than procps pkill.
     os.execute("pkill -9 -f 'abk-progress' 2>/dev/null")
     os.execute("pkill -9 -f 'ffmpeg.*abk-progress' 2>/dev/null")
     os.execute("killall -9 ffmpeg 2>/dev/null")
-    -- gst-launch-0.10 side: every audiobook pipeline uses mixersink with this
-    -- exact stream-type.  This also kills the TTS keepalive, which restarts
-    -- automatically when TTS is used again.
-    os.execute("pkill -9 -f 'mixersink stream-type=Music' 2>/dev/null")
+    -- Content gst side (fdsrc → mixersink).  Keep /dev/zero keepalive alive
+    -- when content_only so pause→resume does not drop the A2DP datapath.
     os.execute("pkill -9 -f 'gst-launch-0.10 fdsrc' 2>/dev/null")
-    os.execute("killall -9 gst-launch-0.10 2>/dev/null")
-    -- Wrapper shells that spawn the above pipelines write their PID to
-    -- kindle-gst-pid-* files; kill them explicitly in case pkill missed them.
     os.execute("pkill -9 -f 'kindle-gst-pid-' 2>/dev/null")
+    if not content_only then
+        -- Full cleanup: every Music mixersink, including TTS/audiobook keepalive.
+        os.execute("pkill -9 -f 'mixersink stream-type=Music' 2>/dev/null")
+        os.execute("killall -9 gst-launch-0.10 2>/dev/null")
+        self._keepalive_pid = nil
+    end
 
     -- Give the mixer a moment to release the old stream before the new one
     -- attaches; without this the new stream can still overlap the tail of the
@@ -1263,21 +1370,23 @@ function MediaEngine:_killOrphanKindleGstPipelines(name, wait_us)
         os.execute("usleep " .. tostring(wait_us))
     end
 
-    -- Verify: on some firmwares pkill/killall silently fail.  Poll until no
-    -- audiobook gst-launch-0.10 process remains, up to a short timeout.
-    local deadline = UIManager:getTime() + 1.5
-    while UIManager:getTime() < deadline do
-        local h = io.popen("pgrep -c 'gst-launch-0.10' 2>/dev/null")
-        local count
-        if h then
-            count = tonumber(h:read("*a"))
-            h:close()
+    if not content_only then
+        -- Verify: on some firmwares pkill/killall silently fail.  Poll until no
+        -- audiobook gst-launch-0.10 process remains, up to a short timeout.
+        local deadline = UIManager:getTime() + 1.5
+        while UIManager:getTime() < deadline do
+            local h = io.popen("pgrep -c 'gst-launch-0.10' 2>/dev/null")
+            local count
+            if h then
+                count = tonumber(h:read("*a"))
+                h:close()
+            end
+            if not count or count == 0 then break end
+            logger.warn("MediaEngine:", count, "gst-launch-0.10 still alive; re-killing")
+            os.execute("killall -9 gst-launch-0.10 2>/dev/null")
+            os.execute("pkill -9 -f 'mixersink stream-type=Music' 2>/dev/null")
+            os.execute("usleep 100000")
         end
-        if not count or count == 0 then break end
-        logger.warn("MediaEngine:", count, "gst-launch-0.10 still alive; re-killing")
-        os.execute("killall -9 gst-launch-0.10 2>/dev/null")
-        os.execute("pkill -9 -f 'mixersink stream-type=Music' 2>/dev/null")
-        os.execute("usleep 100000")
     end
     logger.warn("MediaEngine: orphan Kindle audiobook pipeline cleanup done (", name, ")")
 end
@@ -1380,7 +1489,8 @@ function MediaEngine:_playSystemGstLaunch(gen)
     -- a new stream to mixersink.  If the old pipeline is still draining its
     -- ring buffer while the new one starts, the user hears both streams as an
     -- echo/loop ("this is this is an an example example").
-    self:_killOrphanKindleGstPipelines("kindle-gst-wav", 150000)
+    self:_killOrphanKindleGstPipelines("kindle-gst-wav", 150000,
+        self._keepalive_pid and { content_only = true } or nil)
 
     local caps = string.format(
         "audio/x-raw-int,endianness=1234,signed=true,width=%d,depth=%d,rate=%d,channels=%d",
@@ -1427,7 +1537,8 @@ function MediaEngine:_playSystemGstLaunchFfmpeg(gen)
     -- rapid restart (seek / volume change) that lands inside that window never
     -- tracks the freshly spawned pipeline; stop() then can't kill it and it
     -- keeps playing -> overlapping audio.
-    self:_killOrphanKindleGstPipelines("kindle-gst-ffmpeg", 150000)
+    self:_killOrphanKindleGstPipelines("kindle-gst-ffmpeg", 150000,
+        self._keepalive_pid and { content_only = true } or nil)
 
     -- Take focus after the old pipeline has had a moment to tear down.
     -- AirPods: if the A2DP route is down, force a fresh Music focus so
@@ -2098,17 +2209,24 @@ function MediaEngine:_startA2dpWatchdog(gen)
             if misses >= 2 then
                 MediaEngine._clearMusicFocusFlag()
                 MediaEngine._takeMusicFocusOnce(true)
-                if self:_isAppleAirPodsHeadset() and not self._a2dp_route_restart_done then
+                if not self._a2dp_route_restart_done then
                     self._a2dp_route_restart_done = true
                     local pos = 0
                     pcall(function() pos = self:getPosition() or 0 end)
                     local complete_cb = self._on_complete
                     local fail_cb = self._on_fail
                     self._seek_offset = math.max(0, pos)
-                    logger.warn("MediaEngine: A2DP route recovery restart at", self._seek_offset)
-                    UIManager:scheduleIn(0.4, function()
+                    logger.warn("MediaEngine: A2DP route recovery — BT cycle + restart at",
+                        self._seek_offset)
+                    -- Park keepalive while cycling so we do not go fully idle.
+                    self:_startKindleA2dpKeepalive("route-recovery")
+                    self:_cycleKindleA2dpRoute(function(ok)
                         if self.play_generation ~= gen then return end
+                        logger.warn("MediaEngine: route recovery cycle ok=", ok and "yes" or "no")
                         self:play(complete_cb, fail_cb)
+                        UIManager:scheduleIn(1.2, function()
+                            self:_stopKindleA2dpKeepalive()
+                        end)
                     end)
                     return
                 end
@@ -2263,7 +2381,7 @@ function MediaEngine:pause()
 
     -- Kindle gst/AirPods: do NOT SIGSTOP.  Idle A2DP is torn down by
     -- audiomgrd within seconds; SIGCONT then produces a silent "playing"
-    -- pipeline.  Halt cleanly and remember the position for resume-restart.
+    -- pipeline.  Halt content, park a silence keepalive so A2DP stays up.
     if self:_kindleNeedsPipelineRestartOnResume() then
         local pos = 0
         pcall(function() pos = self:getPosition() or 0 end)
@@ -2272,6 +2390,7 @@ function MediaEngine:pause()
         logger.warn("MediaEngine: Kindle A2DP pause-halt at", self._paused_position,
             "apple=", self:_isAppleAirPodsHeadset() and "yes" or "no")
         self:_haltKindlePipelineForPause("pause-halt")
+        self:_startKindleA2dpKeepalive("pause")
         return
     end
 
@@ -2317,7 +2436,7 @@ function MediaEngine:resume()
         self._pause_start_time = nil
     end
 
-    -- Kindle A2DP: always restart at pause position with fresh Music focus.
+    -- Kindle A2DP: ensure route (keepalive / BT cycle), then restart content.
     if self:_kindleNeedsPipelineRestartOnResume() then
         local pos = self._paused_position
         if pos == nil then
@@ -2326,13 +2445,24 @@ function MediaEngine:resume()
         pos = math.max(0, tonumber(pos) or 0)
         local complete = self._on_complete
         local fail = self._on_fail
+        local resume_gen = self.play_generation
         self.is_paused = false
         self._paused_position = nil
         self._seek_offset = pos
-        MediaEngine._clearMusicFocusFlag()
-        MediaEngine._takeMusicFocusOnce(true)
-        logger.warn("MediaEngine: Kindle A2DP resume-restart at", pos)
-        self:play(complete, fail)
+        logger.warn("MediaEngine: Kindle A2DP resume-restart at", pos,
+            "route_up=", self:_kindleA2dpRouteUp() and "yes" or "no",
+            "keepalive=", self._keepalive_pid or "none")
+        self:_ensureKindleA2dpRoute(function(ok)
+            if self.play_generation ~= resume_gen and self.is_playing and not self.is_paused then
+                -- Another stop/seek superseded this resume.
+            end
+            logger.warn("MediaEngine: resume route ready ok=", ok and "yes" or "no")
+            self:play(complete, fail)
+            -- Drop keepalive after content is attached so it does not mix.
+            UIManager:scheduleIn(1.2, function()
+                self:_stopKindleA2dpKeepalive()
+            end)
+        end)
         return
     end
 
@@ -2411,11 +2541,19 @@ function MediaEngine:stop()
     -- audio running and the user hears overlapping/looping audio.
     -- Run unconditionally on Kindle hardware even if the current backend was
     -- not (yet) detected as KINDLE_GST_PLAY.
+    -- Spare the pause keepalive unless the caller requested a hard stop
+    -- (user Stop / end of book) via _kill_keepalive_on_stop.
     if self:_isKindle() then
         if not dying_pid and not ffi.C.kill then
             logger.warn("MediaEngine: ffi.C.kill unavailable; relying on pkill fallback for Kindle gst")
         end
-        self:_killOrphanKindleGstPipelines("stop")
+        local spare_keepalive = self._keepalive_pid and not self._kill_keepalive_on_stop
+        self:_killOrphanKindleGstPipelines("stop", spare_keepalive and 100000 or 300000,
+            spare_keepalive and { content_only = true } or nil)
+        if not spare_keepalive then
+            self:_stopKindleA2dpKeepalive()
+        end
+        self._kill_keepalive_on_stop = nil
     end
 
     -- Remove the raw PCM temp file created by _playSystemGstLaunch

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -134,6 +134,42 @@ function MediaEngine:_kindleA2dpRouteUp()
     return v:match("^%s*1") ~= nil
 end
 
+--- Kindle A2DP (esp. AirPods): SIGSTOP/SIGCONT leaves the pipeline frozen while
+--- audiomgrd drops the idle headset session — resume must re-attach Music focus
+--- and restart the gst pipeline at the pause position.
+function MediaEngine:_kindleNeedsPipelineRestartOnResume()
+    if not self:_isKindle() then return false end
+    return self.backend == self.BACKENDS.KINDLE_GST_PLAY
+        or self.backend == self.BACKENDS.GST_PLAY
+        or self.backend == self.BACKENDS.GST_PIPELINE
+        or self.backend == self.BACKENDS.FFMPEG_PIPE
+end
+
+--- Halt the Kindle ffmpeg|gst pipeline without clearing pause/callbacks.
+function MediaEngine:_haltKindlePipelineForPause(reason)
+    self:_nextGeneration() -- cancel completion / position watchers
+    if self._position_timer then
+        UIManager:unschedule(self._position_timer)
+        self._position_timer = nil
+    end
+    local pid = self.audio_pid
+    self.audio_pid = nil
+    if pid and ffi.C.kill then
+        pcall(function() ffi.C.kill(-pid, 15) end) -- SIGTERM group
+        pcall(function() ffi.C.kill(pid, 15) end)
+        pcall(function() ffi.C.kill(-pid, 9) end)
+        pcall(function() ffi.C.kill(pid, 9) end)
+    end
+    if self:_isKindle() then
+        self:_killOrphanKindleGstPipelines(reason or "pause-halt", 150000)
+    end
+    if self._progress_file then
+        os.remove(self._progress_file)
+        self._progress_file = nil
+    end
+    self._use_progress_position = false
+end
+
 --[[--
 Build an ffmpeg atempo filter string for the given playback speed.
 atempo accepts 0.5..2.0; chain multiple filters for speeds outside that range.
@@ -2213,6 +2249,7 @@ function MediaEngine:pause()
         elseif self._fifo_path then
             self:_mpvSendFifo("set pause yes")
         end
+        return
     elseif self.backend == self.BACKENDS.MPLAYER then
         if self._ipc_file then
             local f = io.open(self._ipc_file, "w")
@@ -2221,7 +2258,24 @@ function MediaEngine:pause()
                 f:close()
             end
         end
-    elseif self.audio_pid and ffi.C.kill then
+        return
+    end
+
+    -- Kindle gst/AirPods: do NOT SIGSTOP.  Idle A2DP is torn down by
+    -- audiomgrd within seconds; SIGCONT then produces a silent "playing"
+    -- pipeline.  Halt cleanly and remember the position for resume-restart.
+    if self:_kindleNeedsPipelineRestartOnResume() then
+        local pos = 0
+        pcall(function() pos = self:getPosition() or 0 end)
+        self._paused_position = math.max(0, pos)
+        self._seek_offset = self._paused_position
+        logger.warn("MediaEngine: Kindle A2DP pause-halt at", self._paused_position,
+            "apple=", self:_isAppleAirPodsHeadset() and "yes" or "no")
+        self:_haltKindlePipelineForPause("pause-halt")
+        return
+    end
+
+    if self.audio_pid and ffi.C.kill then
         -- Signal the whole process group: for the ffmpeg|gst-launch
         -- pipeline audio_pid is a setsid'd wrapper shell, and stopping
         -- only the shell leaves both pipeline halves playing.
@@ -2258,11 +2312,31 @@ function MediaEngine:resume()
         return
     end
 
-    self.is_paused = false
     if self._pause_start_time then
         self._total_pause_ms = self._total_pause_ms + time.to_ms(UIManager:getTime() - self._pause_start_time)
         self._pause_start_time = nil
     end
+
+    -- Kindle A2DP: always restart at pause position with fresh Music focus.
+    if self:_kindleNeedsPipelineRestartOnResume() then
+        local pos = self._paused_position
+        if pos == nil then
+            pcall(function() pos = self:getPosition() or 0 end)
+        end
+        pos = math.max(0, tonumber(pos) or 0)
+        local complete = self._on_complete
+        local fail = self._on_fail
+        self.is_paused = false
+        self._paused_position = nil
+        self._seek_offset = pos
+        MediaEngine._clearMusicFocusFlag()
+        MediaEngine._takeMusicFocusOnce(true)
+        logger.warn("MediaEngine: Kindle A2DP resume-restart at", pos)
+        self:play(complete, fail)
+        return
+    end
+
+    self.is_paused = false
 
     if self.backend == self.BACKENDS.MPV then
         if self:_hasLuaSocket() and self._socket_path then
@@ -2287,7 +2361,7 @@ function MediaEngine:resume()
         -- After a paused seek the process was killed; restart it.
         if self.audio_pid and ffi.C.kill then
             ffi.C.kill(-self.audio_pid, 18) -- SIGCONT group
-        ffi.C.kill(self.audio_pid, 18)  -- SIGCONT pid
+            ffi.C.kill(self.audio_pid, 18)  -- SIGCONT pid
         else
             self:play(self._on_complete, self._on_fail)
         end
@@ -2476,6 +2550,11 @@ function MediaEngine:seek(seconds, mode)
             end
         end
 
+        -- Keep pause-resume position in sync when seeking while paused.
+        if self.is_paused then
+            self._paused_position = target
+        end
+
         if self._persistent_pipeline_active then
             logger.warn("MediaEngine: persistent-pipeline seek mode=", mode,
                 "req=", seconds, "current=", self:getPosition(),
@@ -2633,6 +2712,11 @@ function MediaEngine:getPosition()
             return self._seek_offset
         end
         return 0
+    end
+
+    -- Kindle A2DP pause-halt: pipeline is gone; hold the saved pause position.
+    if self.is_paused and self._paused_position ~= nil then
+        return self._paused_position
     end
 
     -- ffmpeg -progress backed position (EPUB read-along path): anchored to the

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -699,6 +699,8 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
 
     -- Show playback bar in scrubber mode
     self:showPlaybackBar()
+    -- Reflow page so book text ends above the mini player (never covered).
+    self:_reserveMiniBarSpace()
 
     -- Resume from saved position on initial start, if any.
     if self._start_position and self._start_position > 0 then
@@ -762,6 +764,8 @@ function MediaSync:stop(keep_chapter_menu, opts)
         if self.playback_bar then
             pcall(function() self.playback_bar:hide() end)
         end
+        -- Restore page margins only on hard stop (keep reservation across tracks).
+        self:_releaseMiniBarSpace()
     end
     if not keep_chapter_menu then
         if self._chapter_menu_window then
@@ -775,6 +779,70 @@ function MediaSync:stop(keep_chapter_menu, opts)
 
     if was_playing then
         logger.warn("MediaSync: stopped", track_transition and "(track transition)" or "")
+    end
+end
+
+--- Footer height (status bar + progress) for positioning / margin math.
+function MediaSync:_readerFooterHeight()
+    local ui = self.plugin and self.plugin.ui
+    local view = ui and ui.view
+    if not view or not view.footer or not view.footer_visible then return 0 end
+    local ok, h = pcall(function() return view.footer:getHeight() end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    ok, h = pcall(function()
+        local d = view.footer.dimen
+        return d and d.h or 0
+    end)
+    if ok and type(h) == "number" and h > 0 then return h end
+    return 0
+end
+
+--[[--
+Reserve the mini player's height in the document bottom margin so book text
+reflows above it (same approach as SyncController:_reserveBarSpace for TTS).
+--]]
+function MediaSync:_reserveMiniBarSpace()
+    if self._bar_space_reserved then return end
+    if not self.overlay_mode then return end
+    if not (self.plugin and self.plugin.ui and self.plugin.ui.rolling) then return end
+    local ui = self.plugin.ui
+    local tp = ui.typeset
+    if not (tp and tp.unscaled_margins and ui.document and ui.document.setPageMargins) then
+        return
+    end
+    local bar = self.playback_bar
+    local bar_h = bar and (bar._mini_height or (bar.dimen and bar.dimen.h)) or 0
+    if not bar_h or bar_h <= 0 then
+        bar_h = Screen:scaleBySize(44)
+    end
+    local m = tp.unscaled_margins
+    local bottom = Screen:scaleBySize(m[4]) + bar_h
+    local keep_bars = self.plugin and self.plugin.getSetting
+        and self.plugin:getSetting("keep_reader_status_bars", false)
+    if keep_bars then
+        bottom = bottom + self:_readerFooterHeight()
+    end
+    local ok = pcall(ui.document.setPageMargins, ui.document,
+        Screen:scaleBySize(m[1]), Screen:scaleBySize(m[2]),
+        Screen:scaleBySize(m[3]), bottom)
+    if ok then
+        self._bar_space_reserved = true
+        self._reserved_mini_bar_h = bar_h
+        ui:handleEvent(Event:new("UpdatePos"))
+        logger.warn("MediaSync: reserved", bar_h, "px bottom margin for mini player")
+    end
+end
+
+function MediaSync:_releaseMiniBarSpace()
+    if not self._bar_space_reserved then return end
+    self._bar_space_reserved = false
+    self._reserved_mini_bar_h = nil
+    if not (self.plugin and self.plugin.ui) then return end
+    local ui = self.plugin.ui
+    local tp = ui.typeset
+    if tp and tp.unscaled_margins then
+        ui:handleEvent(Event:new("SetPageMargins", tp.unscaled_margins))
+        logger.warn("MediaSync: restored user page margins after mini player")
     end
 end
 
@@ -1427,6 +1495,7 @@ end
 
 function MediaSync:showPlaybackBar()
     if self.playback_bar and self.playback_bar:isVisible() then
+        self:_reserveMiniBarSpace()
         return
     end
     -- For standalone audio (scrubber mode), use full-screen AudiobookPlayer overlay
@@ -1531,6 +1600,10 @@ function MediaSync:showPlaybackBar()
         end or nil,
         -- BT reconnect lives in plugin settings (Reconnect BT on track change).
         show_fix_audio = false,
+        keep_reader_status_bars = self.plugin
+            and self.plugin.getSetting
+            and self.plugin:getSetting("keep_reader_status_bars", false)
+            or false,
     }
     player:show()
     if self.plugin then
@@ -1540,6 +1613,7 @@ function MediaSync:showPlaybackBar()
         end)
     end
     self.playback_bar = player
+    self:_reserveMiniBarSpace()
 end
 
 function MediaSync:navigateToSentenceAtTime(seconds)

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -741,7 +741,11 @@ function MediaSync:stop(keep_chapter_menu)
     end
 
     if self.media_engine then
-        pcall(function() self.media_engine:stop() end)
+        pcall(function()
+            -- Hard stop: tear down pause keepalive as well as content audio.
+            self.media_engine._kill_keepalive_on_stop = true
+            self.media_engine:stop()
+        end)
     end
     if self.highlight_manager then
         pcall(function() self.highlight_manager:clearHighlights() end)

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -592,7 +592,8 @@ end
 
 function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist_files, original_path, start_position)
     if self.state == self.STATE.PLAYING or self.state == self.STATE.PAUSED then
-        self:stop(true) -- keep chapter menu open during track transitions
+        -- Soft stop: keep A2DP keepalive + player UI across playlist file changes.
+        self:stop(true, { track_transition = true })
     end
 
     if not audio_path or not timing_data or #timing_data == 0 then
@@ -600,6 +601,7 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
         return false
     end
 
+    self._track_advance_pending = nil
     self.state = self.STATE.LOADING
     self.timing_data = timing_data
     self.chapters = chapters or {}
@@ -727,7 +729,11 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
     return true
 end
 
-function MediaSync:stop(keep_chapter_menu)
+--- @param keep_chapter_menu boolean|nil
+--- @param opts table|nil  { track_transition = true } spares A2DP keepalive and player UI
+function MediaSync:stop(keep_chapter_menu, opts)
+    opts = opts or {}
+    local track_transition = opts.track_transition and true or false
     local was_playing = self.state ~= self.STATE.STOPPED
     self.state = self.STATE.STOPPED
     self._chain_generation = self._chain_generation + 1
@@ -743,16 +749,19 @@ function MediaSync:stop(keep_chapter_menu)
 
     if self.media_engine then
         pcall(function()
-            -- Hard stop: tear down pause keepalive as well as content audio.
-            self.media_engine._kill_keepalive_on_stop = true
+            -- Hard stop (user close / end of book): tear down keepalive too.
+            -- Track transition: spare keepalive so AirPods A2DP stays armed.
+            self.media_engine._kill_keepalive_on_stop = not track_transition
             self.media_engine:stop()
         end)
     end
     if self.highlight_manager then
         pcall(function() self.highlight_manager:clearHighlights() end)
     end
-    if self.playback_bar then
-        pcall(function() self.playback_bar:hide() end)
+    if not track_transition then
+        if self.playback_bar then
+            pcall(function() self.playback_bar:hide() end)
+        end
     end
     if not keep_chapter_menu then
         if self._chapter_menu_window then
@@ -765,7 +774,7 @@ function MediaSync:stop(keep_chapter_menu)
     end
 
     if was_playing then
-        logger.warn("MediaSync: stopped")
+        logger.warn("MediaSync: stopped", track_transition and "(track transition)" or "")
     end
 end
 
@@ -936,13 +945,34 @@ function MediaSync:prevChapter()
     end
 end
 
+--- Keepalive (+ optional BT Disconnect/Connect) before switching audio files.
+function MediaSync:_bridgeKindleA2dpForTrackChange(then_fn)
+    local me = self.media_engine
+    local cycle_bt = false
+    if self.plugin and self.plugin.getSetting then
+        cycle_bt = self.plugin:getSetting("kindle_bt_reconnect_on_track", false) and true or false
+    end
+    if me and me.prepareKindleTrackAdvance then
+        me:prepareKindleTrackAdvance(function(_ok)
+            if then_fn then then_fn() end
+        end, { cycle_bt = cycle_bt })
+        return
+    end
+    if me and me._startKindleA2dpKeepalive then
+        pcall(function() me:_startKindleA2dpKeepalive("track-advance") end)
+    end
+    if then_fn then then_fn() end
+end
+
 function MediaSync:switchToPlaylistFile(index)
     if not self.playlist_files or not self.playlist_files[index] then return end
     self.current_playlist_idx = index
     local file_path = self.playlist_files[index].path
-    if self.plugin and self.plugin._playAudioFile then
-        self.plugin:_playAudioFile(file_path, self.playlist_files)
-    end
+    self:_bridgeKindleA2dpForTrackChange(function()
+        if self.plugin and self.plugin._playAudioFile then
+            self.plugin:_playAudioFile(file_path, self.playlist_files)
+        end
+    end)
 end
 
 function MediaSync:toggleLoop()
@@ -1339,21 +1369,30 @@ end
 
 function MediaSync:_onPlaybackComplete(gen)
     if self._chain_generation ~= gen then return end
+    if self._track_advance_pending then
+        logger.warn("MediaSync: playback complete ignored (track advance already pending)")
+        return
+    end
     logger.warn("MediaSync: playback complete")
     -- In playlist mode, auto-advance to the next track
     if self.playlist_files and #self.playlist_files > 0 then
         local next_idx = (self.current_playlist_idx or 1) + 1
         local function advance(idx)
-            -- Bridge Kindle A2DP across the EOS → next-file gap (AirPods).
-            if self.media_engine and self.media_engine._startKindleA2dpKeepalive then
-                pcall(function()
-                    self.media_engine:_startKindleA2dpKeepalive("track-advance")
-                end)
+            self._track_advance_pending = true
+            self._chain_generation = self._chain_generation + 1
+            if self._sync_timer then
+                UIManager:unschedule(self._sync_timer)
+                self._sync_timer = nil
             end
+            if self._position_timer then
+                UIManager:unschedule(self._position_timer)
+                self._position_timer = nil
+            end
+            logger.warn("MediaSync: auto-advancing to playlist track", idx,
+                "(A2DP bridge; BT cycle if setting enabled)")
             self:switchToPlaylistFile(idx)
         end
         if next_idx <= #self.playlist_files then
-            logger.warn("MediaSync: auto-advancing to playlist track", next_idx)
             advance(next_idx)
             return
         elseif self.loop_enabled then
@@ -1490,19 +1529,8 @@ function MediaSync:showPlaybackBar()
         on_refocus = self.overlay_mode and function()
             self:refocusToCurrentSentence()
         end or nil,
-        -- Kindle + AirPods: shortcut to cycle BT A2DP when audio goes silent
-        -- while the UI still shows playback progressing.
-        show_fix_audio = Device.isKindle and Device:isKindle() or false,
-        on_fix_audio = function()
-            if not (self.media_engine and self.media_engine.fixKindleA2dpAudio) then
-                return
-            end
-            UIManager:show(InfoMessage:new{
-                text = _("Reconnecting Bluetooth audio…"),
-                timeout = 4,
-            })
-            self.media_engine:fixKindleA2dpAudio()
-        end,
+        -- BT reconnect lives in plugin settings (Reconnect BT on track change).
+        show_fix_audio = false,
     }
     player:show()
     if self.plugin then

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -6,6 +6,7 @@ Mirrors SyncController patterns but without TTS synthesis or sentence prefetch.
 @module koplugin.audiobook.mediasync
 --]]
 
+local Device = require("device")
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
@@ -1342,9 +1343,18 @@ function MediaSync:_onPlaybackComplete(gen)
     -- In playlist mode, auto-advance to the next track
     if self.playlist_files and #self.playlist_files > 0 then
         local next_idx = (self.current_playlist_idx or 1) + 1
+        local function advance(idx)
+            -- Bridge Kindle A2DP across the EOS → next-file gap (AirPods).
+            if self.media_engine and self.media_engine._startKindleA2dpKeepalive then
+                pcall(function()
+                    self.media_engine:_startKindleA2dpKeepalive("track-advance")
+                end)
+            end
+            self:switchToPlaylistFile(idx)
+        end
         if next_idx <= #self.playlist_files then
             logger.warn("MediaSync: auto-advancing to playlist track", next_idx)
-            self:switchToPlaylistFile(next_idx)
+            advance(next_idx)
             return
         elseif self.loop_enabled then
             -- Loop: wrap back to start (or random if shuffled)
@@ -1355,7 +1365,7 @@ function MediaSync:_onPlaybackComplete(gen)
                 next_idx = 1
             end
             logger.warn("MediaSync: looping to playlist track", next_idx)
-            self:switchToPlaylistFile(next_idx)
+            advance(next_idx)
             return
         end
     end
@@ -1480,6 +1490,19 @@ function MediaSync:showPlaybackBar()
         on_refocus = self.overlay_mode and function()
             self:refocusToCurrentSentence()
         end or nil,
+        -- Kindle + AirPods: shortcut to cycle BT A2DP when audio goes silent
+        -- while the UI still shows playback progressing.
+        show_fix_audio = Device.isKindle and Device:isKindle() or false,
+        on_fix_audio = function()
+            if not (self.media_engine and self.media_engine.fixKindleA2dpAudio) then
+                return
+            end
+            UIManager:show(InfoMessage:new{
+                text = _("Reconnecting Bluetooth audio…"),
+                timeout = 4,
+            })
+            self.media_engine:fixKindleA2dpAudio()
+        end,
     }
     player:show()
     if self.plugin then


### PR DESCRIPTION
## Summary

Hardens Kindle A2DP playback for **Apple AirPods Pro 3** on a jailbroken **Paperwhite 11th gen** (KOReader field tests, Aug 2026).

Fixes the “blip then permanent silence” failure, **pause → play silence until BT reconnect**, and **EOS / playlist-chunk silence** when Storyteller (or any multi-file) audio advances to the next embedded part.

Root cause: Kindle `audiomgrd` drops the A2DP datapath when `mixersink` goes idle across stop→play gaps (seek-by-restart, pause, track advance). Manual Disconnect/Connect re-arms the route; the plugin now bridges that gap.

### Changes
- Skip redundant `seek-by-restart` / stop orphan-killing on PID-capture miss; recover PID via `pgrep`
- AirPods-aware `adelay`/`apad`, Music-focus reclaim, A2DP watchdog
- **Pause keepalive** (silence on `mixersink`, same idea as TTS) + resume with optional **Disconnect/Connect** when `audioOutputConnected` stays down
- **Track-advance bridge**: soft-stop keeps keepalive + player UI across playlist/Storyteller file changes (hard stop was killing the bridge and leaving Play dead in `STOPPED`)
- Cached headset MAC (`ListConnected` → `ListPaired` → last-seen) so BT cycles don’t skip with “no connected MAC”
- Menu: **Bluetooth settings → Reconnect BT on track change** (`kindle_bt_reconnect_on_track`, **off by default**) — optional forced Disconnect→Connect (~5–10 s) before the next file; keepalive still runs either way
- Overlay **BT** shortcut button removed (v0.1.17.22); use the menu setting / plugin BT menu instead
- Companion Storyteller UX (same field device): mini-player **page-margin reserve** so read-aloud chrome never covers book text when status/progress bars stay visible (v0.1.17.23; full page-turn / status-bar UX lives in the Storyteller PR)
- Bug report: Apple headset detection, `btfd` lists, input devices, `btui` probe
- Field doc: [`docs/AIRPODS_PRO3_KINDLE.md`](docs/AIRPODS_PRO3_KINDLE.md)

### Known limitation
**AirPods stem Play/Pause does not work on Kindle PW11.** No AVRCP input device / no `btui` on this firmware. Stem volume and ANC still work. Use on-screen / Kindle controls. Details in the doc. Kobo Libra Colour is a better candidate for stem AVRCP (existing `mtkbtd` path).

## Manual tests (Kindle Paperwhite 11 + AirPods Pro 3)

- [x] First play after connect — audio continues past 1–2 s
- [x] Pause (UI) several seconds → Play — audio returns
- [x] Longer pause (~2 min) → Play — audio returns (keepalive)
- [x] Seek / ±30s while playing — audio continues (seek-bridge)
- [x] Natural EOS → next Storyteller audio part (~4 min chunks) — audio resumes with keepalive; optional BT reconnect setting validated when enabled
- [x] Plugin BT Disconnect/Connect restores stale A2DP route
- [x] **Reconnect BT on track change** (menu) — works well across chunk boundaries
- [x] Play from `STOPPED` after a botched transition — restarts current file
- [x] Bug report shows `kindle_apple_headset` / connected lists
- [x] Stem volume ± and ANC — work (system / headset)
- [ ] Stem Play/Pause — **not available** on this Kindle firmware (documented)

## Related
- Storyteller EPUB3 overlay PR (separate): multiline SMIL / read-aloud UX — tested on same Kindle with Bose QC Ultra Gen1 and AirPods Pro 3
- Platform overview: `docs/PLATFORM_AUDIO.md`

