### PR TITLE
fix(android): MediaPlayer JNI for EPUB Media Overlay on Boox (v0.1.17.34)

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.31",
+    version = "0.1.17.32",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.32",
+    version = "0.1.17.33",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.20",
+    version = "0.1.17.31",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -8,7 +8,7 @@ local _ = require("gettext")
 
 return {
     name = "audiobook",
-    version = "0.1.17.33",
+    version = "0.1.17.34",
     fullname = _("Audiobook Read-Along"),
     description = _([[Text-to-Speech with synchronized word highlighting. Also plays pre-recorded audiobooks (mp3, m4b, m4a) with a seekable scrubber and EPUB 3 Media Overlays (Storyteller format).
 

--- a/android/TtsHelper.java
+++ b/android/TtsHelper.java
@@ -110,7 +110,7 @@ public class TtsHelper implements TextToSpeech.OnInitListener {
                                 if (!pipelineActive || !path.equals(pipelineFile)) {
                                     return;
                                 }
-                                int dur = startPlayback(path);
+                                int dur = startPlayback(path, speechAttributes());
                                 if (dur >= 0) {
                                     pipelineDurationMs = dur;
                                     pipelineStatus = 1;  // playing
@@ -282,16 +282,19 @@ public class TtsHelper implements TextToSpeech.OnInitListener {
 
     // --- Audio focus ---
 
-    /** Speech attributes for playback and focus: route read-along audio the
-     *  same way the platform TTS speak() path is routed, not as music.
-     *  USAGE_MEDIA lands clips on the deep-buffer/offload music path, which
-     *  some HALs (MTK e-ink, Bigme HiBreak, issue #44) tear down ~130 ms
-     *  into a sentence-length clip without ever delivering completion.
-     *  The speak() path works on those devices, so mirror it. */
+    /** Speech attributes for short TTS clips (synth-then-play pipeline). */
     private static AudioAttributes speechAttributes() {
         return new AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY)
             .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build();
+    }
+
+    /** Music/media attributes for pre-recorded audiobook chapters (EPUB overlay). */
+    private static AudioAttributes mediaAttributes() {
+        return new AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
             .build();
     }
 
@@ -300,12 +303,12 @@ public class TtsHelper implements TextToSpeech.OnInitListener {
     private Object audioFocusRequest = null;
 
     @SuppressWarnings("deprecation")
-    private void requestAudioFocus() {
+    private void requestAudioFocus(AudioAttributes attrs) {
         if (audioManager == null) return;
         try {
             if (Build.VERSION.SDK_INT >= 26) {
                 AudioFocusRequest req = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
-                    .setAudioAttributes(speechAttributes())
+                    .setAudioAttributes(attrs != null ? attrs : speechAttributes())
                     .build();
                 audioFocusRequest = req;
                 audioManager.requestAudioFocus(req);
@@ -436,6 +439,18 @@ public class TtsHelper implements TextToSpeech.OnInitListener {
      * thread via JNI) never blocks in media-server binder calls (issue #44).
      */
     public int playFile(final String path) {
+        return playFileWithAttributes(path, speechAttributes());
+    }
+
+    /**
+     * Play a pre-recorded audiobook file (mp3/m4b/…) through the media stream.
+     * Use this for EPUB Media Overlay chapters; short TTS clips use playFile().
+     */
+    public int playMediaFile(final String path) {
+        return playFileWithAttributes(path, mediaAttributes());
+    }
+
+    private int playFileWithAttributes(final String path, final AudioAttributes attrs) {
         if (pipelineActive) {
             pipelineActive = false;
             pipelineStatus = -1;
@@ -445,7 +460,7 @@ public class TtsHelper implements TextToSpeech.OnInitListener {
         worker.post(new Runnable() {
             @Override
             public void run() {
-                startPlayback(path);
+                startPlayback(path, attrs);
             }
         });
         return 0;
@@ -454,18 +469,16 @@ public class TtsHelper implements TextToSpeech.OnInitListener {
     /**
      * Internal: start MediaPlayer on a file.  Runs on the worker thread.
      */
-    private int startPlayback(String path) {
+    private int startPlayback(String path, AudioAttributes attrs) {
         stopPlaybackInternal();
         playbackDone = false;
         playbackActive = false;
-        requestAudioFocus();
+        if (attrs == null) attrs = speechAttributes();
+        requestAudioFocus(attrs);
         synchronized (mpLock) {
             try {
                 mediaPlayer = new MediaPlayer();
-                // Route as speech/assistance, not music: the deep-buffer
-                // music path kills sentence-length clips on some HALs
-                // (Bigme HiBreak, issue #44).
-                mediaPlayer.setAudioAttributes(speechAttributes());
+                mediaPlayer.setAudioAttributes(attrs);
                 mediaPlayer.setDataSource(path);
                 mediaPlayer.setOnCompletionListener(mp -> {
                     playbackDone = true;
@@ -591,6 +604,25 @@ public class TtsHelper implements TextToSpeech.OnInitListener {
                             playbackActive = true;
                         }
                     } catch (IllegalStateException ignored) {}
+                }
+            }
+        });
+    }
+
+    /**
+     * Seek the active MediaPlayer (JNI entry point: posted, never blocks).
+     * Used by EPUB Media Overlay read-aloud on Android (Boox, etc.).
+     */
+    public void seekToMs(final int msec) {
+        worker.post(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (mpLock) {
+                    try {
+                        if (mediaPlayer != null) {
+                            mediaPlayer.seekTo(Math.max(0, msec));
+                        }
+                    } catch (Exception ignored) {}
                 }
             }
         });

--- a/androidplayer.lua
+++ b/androidplayer.lua
@@ -1,0 +1,423 @@
+--[[--
+Android MediaPlayer for audiobook / EPUB Media Overlay playback.
+
+Creates android.media.MediaPlayer directly via JNI — no tts_helper.dex and
+no bundled ffmpeg.  The glibc ffmpeg shipped in the plugin SIGSEGVs on
+Android (Bionic), which was crashing KOReader on "Play aligned audiobook".
+
+@module androidplayer
+--]]
+
+local ffi = require("ffi")
+local logger = require("logger")
+local UIManager = require("ui/uimanager")
+local time = require("ui/time")
+
+local AndroidPlayer = {}
+
+local function checkException(env)
+    if env[0].ExceptionCheck(env) ~= 0 then
+        env[0].ExceptionDescribe(env)
+        env[0].ExceptionClear(env)
+        return true
+    end
+    return false
+end
+
+local function getMethod(env, clazz, name, sig)
+    local mid = env[0].GetMethodID(env, clazz, name, sig)
+    if checkException(env) or mid == nil then return nil end
+    local ok, nullish = pcall(function()
+        return tonumber(ffi.cast("intptr_t", mid)) == 0
+    end)
+    if ok and nullish then return nil end
+    return mid
+end
+
+local function getStaticMethod(env, clazz, name, sig)
+    local mid = env[0].GetStaticMethodID(env, clazz, name, sig)
+    if checkException(env) or mid == nil then return nil end
+    local ok, nullish = pcall(function()
+        return tonumber(ffi.cast("intptr_t", mid)) == 0
+    end)
+    if ok and nullish then return nil end
+    return mid
+end
+
+function AndroidPlayer:new(o)
+    o = o or {}
+    setmetatable(o, self)
+    self.__index = self
+    o._android = nil
+    o._mp_ref = nil
+    o._mp_class = nil
+    o._method = {}
+    o._initialized = false
+    o._duration_ms = 0
+    o._playing = false
+    o._paused = false
+    o._start_seek_ms = 0
+    o._wall_start = nil
+    o._pause_accum_ms = 0
+    o._pause_wall_start = nil
+    o._ever_confirmed_playing = false
+    o._last_mp_pos_ms = 0
+    return o
+end
+
+function AndroidPlayer:init()
+    if self._initialized then return true end
+
+    local Device = require("device")
+    if not (Device.isAndroid and Device:isAndroid()) then
+        return false
+    end
+
+    local ok, android = pcall(require, "android")
+    if not ok or not android then
+        logger.err("AndroidPlayer: cannot load android module")
+        return false
+    end
+    self._android = android
+
+    local load_ok = false
+    android.jni:context(android.app.activity.vm, function(jni)
+        local env = jni.env
+        local mp_class = env[0].FindClass(env, "android/media/MediaPlayer")
+        if checkException(env) or mp_class == nil then
+            logger.err("AndroidPlayer: MediaPlayer class not found")
+            return
+        end
+
+        self._method.init = getMethod(env, mp_class, "<init>", "()V")
+        self._method.setDataSource = getMethod(env, mp_class,
+            "setDataSource", "(Ljava/lang/String;)V")
+        self._method.prepare = getMethod(env, mp_class, "prepare", "()V")
+        self._method.start = getMethod(env, mp_class, "start", "()V")
+        self._method.pause = getMethod(env, mp_class, "pause", "()V")
+        self._method.stop = getMethod(env, mp_class, "stop", "()V")
+        self._method.reset = getMethod(env, mp_class, "reset", "()V")
+        self._method.release = getMethod(env, mp_class, "release", "()V")
+        self._method.seekTo = getMethod(env, mp_class, "seekTo", "(I)V")
+        self._method.isPlaying = getMethod(env, mp_class, "isPlaying", "()Z")
+        self._method.getCurrentPosition = getMethod(env, mp_class,
+            "getCurrentPosition", "()I")
+        self._method.getDuration = getMethod(env, mp_class, "getDuration", "()I")
+        self._method.setAudioAttributes = getMethod(env, mp_class,
+            "setAudioAttributes", "(Landroid/media/AudioAttributes;)V")
+
+        if not self._method.init
+            or not self._method.setDataSource
+            or not self._method.prepare
+            or not self._method.start
+            or not self._method.seekTo
+            or not self._method.getCurrentPosition then
+            logger.err("AndroidPlayer: required MediaPlayer methods missing")
+            env[0].DeleteLocalRef(env, mp_class)
+            return
+        end
+
+        -- Build AudioAttributes USAGE_MEDIA / CONTENT_TYPE_MUSIC once.
+        self._attrs_ref = nil
+        local aa_class = env[0].FindClass(env, "android/media/AudioAttributes")
+        local builder_class = env[0].FindClass(env,
+            "android/media/AudioAttributes$Builder")
+        if aa_class and builder_class and not checkException(env) then
+            local b_init = getMethod(env, builder_class, "<init>", "()V")
+            local set_usage = getMethod(env, builder_class,
+                "setUsage", "(I)Landroid/media/AudioAttributes$Builder;")
+            local set_ctype = getMethod(env, builder_class,
+                "setContentType", "(I)Landroid/media/AudioAttributes$Builder;")
+            local build = getMethod(env, builder_class,
+                "build", "()Landroid/media/AudioAttributes;")
+            -- USAGE_MEDIA=1, CONTENT_TYPE_MUSIC=2
+            if b_init and set_usage and set_ctype and build then
+                local builder = env[0].NewObject(env, builder_class, b_init)
+                if builder and not checkException(env) then
+                    local args = ffi.new("jvalue[1]")
+                    args[0].i = 1  -- USAGE_MEDIA
+                    builder = env[0].CallObjectMethodA(env, builder, set_usage, args)
+                    checkException(env)
+                    args[0].i = 2  -- CONTENT_TYPE_MUSIC
+                    builder = env[0].CallObjectMethodA(env, builder, set_ctype, args)
+                    checkException(env)
+                    local attrs = env[0].CallObjectMethod(env, builder, build)
+                    if attrs and not checkException(env) then
+                        self._attrs_ref = env[0].NewGlobalRef(env, attrs)
+                        env[0].DeleteLocalRef(env, attrs)
+                    end
+                    if builder then env[0].DeleteLocalRef(env, builder) end
+                end
+            end
+            env[0].DeleteLocalRef(env, aa_class)
+            env[0].DeleteLocalRef(env, builder_class)
+        else
+            checkException(env)
+        end
+
+        self._mp_class = env[0].NewGlobalRef(env, mp_class)
+        env[0].DeleteLocalRef(env, mp_class)
+        load_ok = true
+    end)
+
+    if not load_ok then return false end
+    self._initialized = true
+    logger.warn("AndroidPlayer: ready (direct MediaPlayer, no dex)")
+    return true
+end
+
+function AndroidPlayer:_releasePlayer()
+    if not self._mp_ref then return end
+    local android = self._android
+    local mp = self._mp_ref
+    self._mp_ref = nil
+    self._playing = false
+    self._paused = false
+    android.jni:context(android.app.activity.vm, function(jni)
+        local env = jni.env
+        pcall(function()
+            if self._method.reset then
+                env[0].CallVoidMethod(env, mp, self._method.reset)
+                checkException(env)
+            end
+            if self._method.release then
+                env[0].CallVoidMethod(env, mp, self._method.release)
+                checkException(env)
+            end
+        end)
+        env[0].DeleteGlobalRef(env, mp)
+    end)
+end
+
+--- Play a local file.  Optional seek_ms applied after prepare.
+--- @return boolean success
+function AndroidPlayer:play(path, seek_ms)
+    if not self._initialized then return false end
+    seek_ms = math.floor(tonumber(seek_ms) or 0)
+    self:_releasePlayer()
+
+    local android = self._android
+    local ok = false
+    local duration_ms = 0
+
+    android.jni:context(android.app.activity.vm, function(jni)
+        local env = jni.env
+        local mp = env[0].NewObject(env, self._mp_class, self._method.init)
+        if checkException(env) or mp == nil then
+            logger.err("AndroidPlayer: MediaPlayer() failed")
+            return
+        end
+
+        if self._attrs_ref and self._method.setAudioAttributes then
+            env[0].CallVoidMethod(env, mp, self._method.setAudioAttributes,
+                self._attrs_ref)
+            checkException(env)
+        end
+
+        local j_path = env[0].NewStringUTF(env, path)
+        env[0].CallVoidMethod(env, mp, self._method.setDataSource, j_path)
+        env[0].DeleteLocalRef(env, j_path)
+        if checkException(env) then
+            logger.err("AndroidPlayer: setDataSource failed for", path)
+            env[0].CallVoidMethod(env, mp, self._method.release)
+            checkException(env)
+            env[0].DeleteLocalRef(env, mp)
+            return
+        end
+
+        env[0].CallVoidMethod(env, mp, self._method.prepare)
+        if checkException(env) then
+            logger.err("AndroidPlayer: prepare failed for", path)
+            env[0].CallVoidMethod(env, mp, self._method.release)
+            checkException(env)
+            env[0].DeleteLocalRef(env, mp)
+            return
+        end
+
+        if self._method.getDuration then
+            duration_ms = env[0].CallIntMethod(env, mp, self._method.getDuration)
+            checkException(env)
+        end
+
+        if seek_ms > 50 then
+            local sargs = ffi.new("jvalue[1]")
+            sargs[0].i = seek_ms
+            env[0].CallVoidMethodA(env, mp, self._method.seekTo, sargs)
+            checkException(env)
+        end
+
+        env[0].CallVoidMethod(env, mp, self._method.start)
+        if checkException(env) then
+            logger.err("AndroidPlayer: start failed")
+            env[0].CallVoidMethod(env, mp, self._method.release)
+            checkException(env)
+            env[0].DeleteLocalRef(env, mp)
+            return
+        end
+
+        self._mp_ref = env[0].NewGlobalRef(env, mp)
+        env[0].DeleteLocalRef(env, mp)
+        ok = true
+    end)
+
+    if ok then
+        self._duration_ms = duration_ms or 0
+        self._playing = true
+        self._paused = false
+        self._start_seek_ms = math.max(0, seek_ms)
+        -- UIManager time is real wall-clock; os.clock() is CPU time and barely
+        -- advances while KOReader is idle (the Boox timer/highlight bug).
+        self._wall_start = UIManager:getTime()
+        self._pause_accum_ms = 0
+        self._pause_wall_start = nil
+        self._ever_confirmed_playing = true
+        self._last_mp_pos_ms = self._start_seek_ms
+        logger.warn("AndroidPlayer: playing", path,
+            "seek_ms=", seek_ms, "duration_ms=", self._duration_ms)
+    end
+    return ok
+end
+
+function AndroidPlayer:_wallPositionMs()
+    if not self._wall_start then return self._start_seek_ms or 0 end
+    local elapsed
+    if self._paused and self._pause_wall_start then
+        elapsed = time.to_ms(self._pause_wall_start - self._wall_start)
+    else
+        elapsed = time.to_ms(UIManager:getTime() - self._wall_start)
+    end
+    elapsed = (elapsed or 0) - (self._pause_accum_ms or 0)
+    local pos = (self._start_seek_ms or 0) + math.max(0, elapsed)
+    if self._duration_ms and self._duration_ms > 0 then
+        pos = math.min(pos, self._duration_ms)
+    end
+    return math.floor(pos)
+end
+
+function AndroidPlayer:pause()
+    if not self._mp_ref or not self._playing or self._paused then return end
+    local android = self._android
+    android.jni:context(android.app.activity.vm, function(jni)
+        jni.env[0].CallVoidMethod(jni.env, self._mp_ref, self._method.pause)
+        checkException(jni.env)
+    end)
+    self._paused = true
+    self._pause_wall_start = UIManager:getTime()
+end
+
+function AndroidPlayer:resume()
+    if not self._mp_ref or not self._paused then return end
+    local android = self._android
+    android.jni:context(android.app.activity.vm, function(jni)
+        jni.env[0].CallVoidMethod(jni.env, self._mp_ref, self._method.start)
+        checkException(jni.env)
+    end)
+    if self._pause_wall_start then
+        self._pause_accum_ms = (self._pause_accum_ms or 0)
+            + time.to_ms(UIManager:getTime() - self._pause_wall_start)
+        self._pause_wall_start = nil
+    end
+    self._paused = false
+    self._playing = true
+end
+
+function AndroidPlayer:stop()
+    self:_releasePlayer()
+    self._wall_start = nil
+    self._ever_confirmed_playing = false
+end
+
+function AndroidPlayer:seekToMs(msec)
+    if not self._mp_ref then return end
+    msec = math.floor(tonumber(msec) or 0)
+    local android = self._android
+    android.jni:context(android.app.activity.vm, function(jni)
+        local env = jni.env
+        local args = ffi.new("jvalue[1]")
+        args[0].i = msec
+        env[0].CallVoidMethodA(env, self._mp_ref, self._method.seekTo, args)
+        checkException(env)
+    end)
+    self._start_seek_ms = msec
+    self._wall_start = UIManager:getTime()
+    self._pause_accum_ms = 0
+    self._pause_wall_start = nil
+    self._last_mp_pos_ms = msec
+end
+
+--- Position for completion checks (wall-clock; JNI getCurrentPosition is flaky).
+function AndroidPlayer:getPositionMs()
+    return self:_wallPositionMs()
+end
+
+function AndroidPlayer:getDurationMs()
+    if self._duration_ms and self._duration_ms > 0 then
+        return self._duration_ms
+    end
+    if not self._mp_ref or not self._method.getDuration then return 0 end
+    local android = self._android
+    local dur = android.jni:context(android.app.activity.vm, function(jni)
+        local d = jni.env[0].CallIntMethod(jni.env,
+            self._mp_ref, self._method.getDuration)
+        if checkException(jni.env) then return 0 end
+        return tonumber(d) or 0
+    end) or 0
+    self._duration_ms = dur
+    return dur
+end
+
+function AndroidPlayer:isPlaying()
+    if not self._mp_ref then return false end
+    if self._paused then return false end
+    -- Trust our own state: MediaPlayer.isPlaying() is flaky across JNI and
+    -- would false-complete the sync loop while audio still plays.
+    return self._playing and true or false
+end
+
+function AndroidPlayer:isPlaybackDone()
+    if not self._mp_ref then return true end
+    if self._paused then return false end
+    if not self._playing then return true end
+
+    local pos = self:getPositionMs()
+    local dur = self:getDurationMs()
+    if dur and dur > 0 and pos >= (dur - 400) then
+        self._playing = false
+        return true
+    end
+
+    -- Secondary check: MediaPlayer reports stopped after we were confirmed playing.
+    if self._ever_confirmed_playing then
+        local android = self._android
+        local mp_playing = android.jni:context(android.app.activity.vm, function(jni)
+            local r = jni.env[0].CallBooleanMethod(jni.env,
+                self._mp_ref, self._method.isPlaying)
+            if checkException(jni.env) then return true end -- assume still playing on error
+            return r ~= 0
+        end)
+        if mp_playing == false and pos > (self._start_seek_ms or 0) + 2000 then
+            self._playing = false
+            return true
+        end
+    end
+    return false
+end
+
+function AndroidPlayer:shutdown()
+    self:stop()
+    if self._attrs_ref and self._android then
+        self._android.jni:context(self._android.app.activity.vm, function(jni)
+            jni.env[0].DeleteGlobalRef(jni.env, self._attrs_ref)
+        end)
+        self._attrs_ref = nil
+    end
+    if self._mp_class and self._android then
+        self._android.jni:context(self._android.app.activity.vm, function(jni)
+            jni.env[0].DeleteGlobalRef(jni.env, self._mp_class)
+        end)
+        self._mp_class = nil
+    end
+    self._initialized = false
+end
+
+return AndroidPlayer

--- a/androidplayer.lua
+++ b/androidplayer.lua
@@ -309,45 +309,43 @@ function AndroidPlayer:_reanchorWallToMs(pos_ms)
     self._last_mp_pos_ms = pos_ms
 end
 
---- True once MediaPlayer position has moved past startup buffering.
-function AndroidPlayer:_confirmAudioStarted(mp)
+--- One-shot: wait until audio is actually moving, then lock wall-clock to that
+--- position.  After this, sync uses only wall time (monotonic) so highlights
+--- never thrash from flaky MediaPlayer.getCurrentPosition() readings.
+function AndroidPlayer:_tryLockWallClock(mp)
     if self._audio_started then return true end
-    if mp == nil then return false end
-
-    if self._mp_baseline_ms == nil then
-        self._mp_baseline_ms = mp
-    end
 
     local seek = self._start_seek_ms or 0
-    local advanced = mp > (self._mp_baseline_ms or 0) + 40
-        or mp > seek + 40
+    local now = UIManager:getTime()
+    local wait_ms = 0
+    if self._wall_start then
+        wait_ms = time.to_ms(now - self._wall_start) or 0
+    end
 
-    if advanced then
+    if mp ~= nil then
+        if self._mp_baseline_ms == nil then
+            self._mp_baseline_ms = mp
+        end
+        local advanced = mp > (self._mp_baseline_ms or 0) + 60
+            or mp > seek + 60
+        if advanced then
+            self._audio_started = true
+            self._ever_confirmed_playing = true
+            self:_reanchorWallToMs(mp)
+            logger.warn("AndroidPlayer: wall locked to MP pos_ms=", mp,
+                "after", wait_ms, "ms")
+            return true
+        end
+    end
+
+    -- Boox often reports a stuck seek position over JNI: unlock after a short
+    -- grace so highlights still start, slightly late rather than never.
+    if wait_ms >= 350 then
         self._audio_started = true
         self._ever_confirmed_playing = true
-        self:_reanchorWallToMs(mp)
+        self:_reanchorWallToMs(seek)
+        logger.warn("AndroidPlayer: wall locked to seek after grace", wait_ms, "ms")
         return true
-    end
-
-    -- MP reports the seek point but never ticks (common JNI quirk on some devices).
-    if self._wall_start and mp ~= nil and mp >= seek - 80 then
-        local wait_ms = time.to_ms(UIManager:getTime() - self._wall_start)
-        if wait_ms > 600 then
-            self._audio_started = true
-            self._ever_confirmed_playing = true
-            self:_reanchorWallToMs(seek)
-            return true
-        end
-    end
-
-    -- Fallback: wall clock ran far ahead while MP never ticked (flaky JNI).
-    if self._wall_start then
-        local wait_ms = time.to_ms(UIManager:getTime() - self._wall_start)
-        if wait_ms > 2500 then
-            self._audio_started = true
-            self._ever_confirmed_playing = true
-            return true
-        end
     end
     return false
 end
@@ -393,9 +391,8 @@ function AndroidPlayer:resume()
     end
     self._paused = false
     self._playing = true
-    self._audio_started = false
-    self._mp_baseline_ms = nil
-    self._mp_stuck_reads = 0
+    -- Keep wall clock continuous across pause/resume — do NOT re-enter the
+    -- startup lock dance (that caused highlight thrashing on stop/restart).
 end
 
 function AndroidPlayer:stop()
@@ -418,60 +415,29 @@ function AndroidPlayer:seekToMs(msec)
         env[0].CallVoidMethodA(env, self._mp_ref, self._method.seekTo, args)
         checkException(env)
     end)
-    self._start_seek_ms = msec
-    self._wall_start = UIManager:getTime()
-    self._pause_accum_ms = 0
-    self._pause_wall_start = nil
-    self._last_mp_pos_ms = msec
-    self._audio_started = false
+    self:_reanchorWallToMs(msec)
+    self._audio_started = true
+    self._ever_confirmed_playing = true
     self._mp_baseline_ms = nil
     self._mp_stuck_reads = 0
 end
 
---- Position for sync and completion.  Prefer MediaPlayer.getCurrentPosition()
---- once playback has actually started; hold at the seek point during startup
---- buffering so highlights do not race ahead of audible audio.
+--- Position for sync and completion: monotonic wall-clock after a one-shot
+--- lock at audible start.  Never poll MediaPlayer continuously for sync —
+--- on Boox getCurrentPosition() jitters and made highlights thrash.
 function AndroidPlayer:getPositionMs()
     if self._paused then
         return self:_wallPositionMs()
     end
 
-    local seek = self._start_seek_ms or 0
-    local mp = self:_queryMpPositionMs()
-
-    if not self:_confirmAudioStarted(mp) then
-        return seek
-    end
-
-    if mp ~= nil then
-        if mp >= (self._last_mp_pos_ms or 0) - 120 then
-            if mp == self._last_mp_pos_ms then
-                self._mp_stuck_reads = (self._mp_stuck_reads or 0) + 1
-            else
-                self._mp_stuck_reads = 0
-            end
-            self._last_mp_pos_ms = mp
-
-            local wall = self:_wallPositionMs()
-            if wall > mp + 250 then
-                self:_reanchorWallToMs(mp)
-            end
-            return mp
-        end
-
-        -- MP jumped backward (seek/race): trust it and re-anchor.
-        if mp + 120 < (self._last_mp_pos_ms or 0) then
-            self:_reanchorWallToMs(mp)
-            return mp
+    if not self._audio_started then
+        local mp = self:_queryMpPositionMs()
+        if not self:_tryLockWallClock(mp) then
+            return self._start_seek_ms or 0
         end
     end
 
-    -- MP unreadable or stuck for many polls: fall back to wall clock.
-    if (self._mp_stuck_reads or 0) > 8 then
-        return self:_wallPositionMs()
-    end
-
-    return self._last_mp_pos_ms or seek
+    return self:_wallPositionMs()
 end
 
 function AndroidPlayer:getDurationMs()

--- a/androidplayer.lua
+++ b/androidplayer.lua
@@ -62,6 +62,9 @@ function AndroidPlayer:new(o)
     o._pause_wall_start = nil
     o._ever_confirmed_playing = false
     o._last_mp_pos_ms = 0
+    o._audio_started = false
+    o._mp_baseline_ms = nil
+    o._mp_stuck_reads = 0
     return o
 end
 
@@ -173,6 +176,9 @@ function AndroidPlayer:_releasePlayer()
     self._mp_ref = nil
     self._playing = false
     self._paused = false
+    self._audio_started = false
+    self._mp_baseline_ms = nil
+    self._mp_stuck_reads = 0
     android.jni:context(android.app.activity.vm, function(jni)
         local env = jni.env
         pcall(function()
@@ -270,12 +276,80 @@ function AndroidPlayer:play(path, seek_ms)
         self._wall_start = UIManager:getTime()
         self._pause_accum_ms = 0
         self._pause_wall_start = nil
-        self._ever_confirmed_playing = true
+        self._ever_confirmed_playing = false
         self._last_mp_pos_ms = self._start_seek_ms
+        self._audio_started = false
+        self._mp_baseline_ms = nil
+        self._mp_stuck_reads = 0
         logger.warn("AndroidPlayer: playing", path,
             "seek_ms=", seek_ms, "duration_ms=", self._duration_ms)
     end
     return ok
+end
+
+function AndroidPlayer:_queryMpPositionMs()
+    if not self._mp_ref or not self._method.getCurrentPosition then return nil end
+    local android = self._android
+    local pos = android.jni:context(android.app.activity.vm, function(jni)
+        local p = jni.env[0].CallIntMethod(jni.env,
+            self._mp_ref, self._method.getCurrentPosition)
+        if checkException(jni.env) then return nil end
+        return tonumber(p)
+    end)
+    if pos == nil then return nil end
+    return math.max(0, math.floor(pos))
+end
+
+function AndroidPlayer:_reanchorWallToMs(pos_ms)
+    pos_ms = math.floor(tonumber(pos_ms) or 0)
+    self._wall_start = UIManager:getTime()
+    self._start_seek_ms = pos_ms
+    self._pause_accum_ms = 0
+    self._pause_wall_start = nil
+    self._last_mp_pos_ms = pos_ms
+end
+
+--- True once MediaPlayer position has moved past startup buffering.
+function AndroidPlayer:_confirmAudioStarted(mp)
+    if self._audio_started then return true end
+    if mp == nil then return false end
+
+    if self._mp_baseline_ms == nil then
+        self._mp_baseline_ms = mp
+    end
+
+    local seek = self._start_seek_ms or 0
+    local advanced = mp > (self._mp_baseline_ms or 0) + 40
+        or mp > seek + 40
+
+    if advanced then
+        self._audio_started = true
+        self._ever_confirmed_playing = true
+        self:_reanchorWallToMs(mp)
+        return true
+    end
+
+    -- MP reports the seek point but never ticks (common JNI quirk on some devices).
+    if self._wall_start and mp ~= nil and mp >= seek - 80 then
+        local wait_ms = time.to_ms(UIManager:getTime() - self._wall_start)
+        if wait_ms > 600 then
+            self._audio_started = true
+            self._ever_confirmed_playing = true
+            self:_reanchorWallToMs(seek)
+            return true
+        end
+    end
+
+    -- Fallback: wall clock ran far ahead while MP never ticked (flaky JNI).
+    if self._wall_start then
+        local wait_ms = time.to_ms(UIManager:getTime() - self._wall_start)
+        if wait_ms > 2500 then
+            self._audio_started = true
+            self._ever_confirmed_playing = true
+            return true
+        end
+    end
+    return false
 end
 
 function AndroidPlayer:_wallPositionMs()
@@ -319,12 +393,18 @@ function AndroidPlayer:resume()
     end
     self._paused = false
     self._playing = true
+    self._audio_started = false
+    self._mp_baseline_ms = nil
+    self._mp_stuck_reads = 0
 end
 
 function AndroidPlayer:stop()
     self:_releasePlayer()
     self._wall_start = nil
     self._ever_confirmed_playing = false
+    self._audio_started = false
+    self._mp_baseline_ms = nil
+    self._mp_stuck_reads = 0
 end
 
 function AndroidPlayer:seekToMs(msec)
@@ -343,11 +423,55 @@ function AndroidPlayer:seekToMs(msec)
     self._pause_accum_ms = 0
     self._pause_wall_start = nil
     self._last_mp_pos_ms = msec
+    self._audio_started = false
+    self._mp_baseline_ms = nil
+    self._mp_stuck_reads = 0
 end
 
---- Position for completion checks (wall-clock; JNI getCurrentPosition is flaky).
+--- Position for sync and completion.  Prefer MediaPlayer.getCurrentPosition()
+--- once playback has actually started; hold at the seek point during startup
+--- buffering so highlights do not race ahead of audible audio.
 function AndroidPlayer:getPositionMs()
-    return self:_wallPositionMs()
+    if self._paused then
+        return self:_wallPositionMs()
+    end
+
+    local seek = self._start_seek_ms or 0
+    local mp = self:_queryMpPositionMs()
+
+    if not self:_confirmAudioStarted(mp) then
+        return seek
+    end
+
+    if mp ~= nil then
+        if mp >= (self._last_mp_pos_ms or 0) - 120 then
+            if mp == self._last_mp_pos_ms then
+                self._mp_stuck_reads = (self._mp_stuck_reads or 0) + 1
+            else
+                self._mp_stuck_reads = 0
+            end
+            self._last_mp_pos_ms = mp
+
+            local wall = self:_wallPositionMs()
+            if wall > mp + 250 then
+                self:_reanchorWallToMs(mp)
+            end
+            return mp
+        end
+
+        -- MP jumped backward (seek/race): trust it and re-anchor.
+        if mp + 120 < (self._last_mp_pos_ms or 0) then
+            self:_reanchorWallToMs(mp)
+            return mp
+        end
+    end
+
+    -- MP unreadable or stuck for many polls: fall back to wall clock.
+    if (self._mp_stuck_reads or 0) > 8 then
+        return self:_wallPositionMs()
+    end
+
+    return self._last_mp_pos_ms or seek
 end
 
 function AndroidPlayer:getDurationMs()

--- a/androidtts.lua
+++ b/androidtts.lua
@@ -16,6 +16,15 @@ local logger = require("logger")
 
 local AndroidTts = {}
 
+--- io.open can fail on Android for plugin paths; fall back to test(1).
+local function fileExists(path)
+    if not path or path == "" then return false end
+    local f = io.open(path, "r")
+    if f then f:close() return true end
+    local rc = os.execute('test -f "' .. path:gsub('"', '\\"') .. '" 2>/dev/null')
+    return rc == 0 or rc == true
+end
+
 function AndroidTts:new(o)
     o = o or {}
     setmetatable(o, self)
@@ -47,6 +56,22 @@ local function checkException(env)
     return false
 end
 
+--- LuaJIT treats a NULL cdata pointer as truthy.  Convert failed GetMethodID
+--- results to real nil so callers never Call*Method with a null jmethodID
+--- (that hard-crashes the Android process).
+local function getMethod(env, clazz, name, sig)
+    local mid = env[0].GetMethodID(env, clazz, name, sig)
+    if checkException(env) or mid == nil then
+        return nil
+    end
+    -- Explicit NULL-pointer check for LuaJIT FFI jmethodID
+    local ok, nullish = pcall(function()
+        return tonumber(ffi.cast("intptr_t", mid)) == 0
+    end)
+    if ok and nullish then return nil end
+    return mid
+end
+
 --[[--
 Initialize the Android TTS engine.
 Loads the helper .dex via DexClassLoader and creates a TtsHelper instance.
@@ -68,22 +93,33 @@ function AndroidTts:init()
     end
     self._android = android
 
-    -- Check that the .dex helper file exists (with fallback to this file's dir)
-    local dex_path = self.plugin_dir .. "/android/tts_helper.dex"
-    local f = io.open(dex_path, "r")
-    if not f then
-        local fallback_dir = debug.getinfo(1, "S").source:match("^@(.*/)[^/]*$") or "."
+    -- Locate tts_helper.dex (plugin dir, then this file's dir).
+    local dex_path = nil
+    local plugin_dir = (self.plugin_dir or "."):gsub("//+", "/"):gsub("/+$", "")
+    local candidates = {
+        plugin_dir .. "/android/tts_helper.dex",
+    }
+    local fallback_dir = debug.getinfo(1, "S").source:match("^@(.*/)[^/]*$")
+    if fallback_dir then
         fallback_dir = fallback_dir:gsub("//+", "/"):gsub("/+$", "")
-        dex_path = fallback_dir .. "/android/tts_helper.dex"
-        f = io.open(dex_path, "r")
-        if not f then
-            logger.err("AndroidTts: tts_helper.dex not found. Checked plugin_dir:", self.plugin_dir, "and fallback:", fallback_dir)
-            return false
-        end
-        -- Update plugin_dir so subsequent path lookups also work
-        self.plugin_dir = fallback_dir
+        table.insert(candidates, fallback_dir .. "/android/tts_helper.dex")
     end
-    f:close()
+    for _, candidate in ipairs(candidates) do
+        if fileExists(candidate) then
+            dex_path = candidate
+            if candidate:find(plugin_dir, 1, true) == 1 then
+                self.plugin_dir = plugin_dir
+            elseif fallback_dir then
+                self.plugin_dir = fallback_dir
+            end
+            break
+        end
+    end
+    if not dex_path then
+        logger.err("AndroidTts: tts_helper.dex not found. Checked:",
+            table.concat(candidates, ", "))
+        return false
+    end
 
     -- Resolve the cache directory for DexClassLoader's optimized dex output
     -- and for WAV file storage.
@@ -95,6 +131,10 @@ function AndroidTts:init()
     self._cache_dir = cache_dir
     -- Ensure the audiobook cache subdirectory exists
     os.execute('mkdir -p "' .. cache_dir .. '/audiobook"')
+
+    -- Load the .dex from the plugin folder (proven path on Boox).  cache_dir
+    -- is only passed to DexClassLoader as the optimized-dex output dir.
+    -- Do NOT io.open(..., "rb") here — KOReader Lua on Android can hard-crash.
 
     -- Load the helper via DexClassLoader inside a JNI context
     local load_ok = false
@@ -187,51 +227,61 @@ function AndroidTts:init()
             return
         end
 
-        -- 5. Cache method IDs (valid as long as the class is loaded)
-        self._method.getInitStatus = env[0].GetMethodID(env, helper_class,
+        -- 5. Cache method IDs (valid as long as the class is loaded).
+        -- Use getMethod() so missing methods become Lua nil (not NULL cdata).
+        self._method.getInitStatus = getMethod(env, helper_class,
             "getInitStatus", "()I")
-        self._method.synthesizeToFile = env[0].GetMethodID(env, helper_class,
+        self._method.synthesizeToFile = getMethod(env, helper_class,
             "synthesizeToFile", "(Ljava/lang/String;Ljava/lang/String;)I")
-        self._method.getSynthStatus = env[0].GetMethodID(env, helper_class,
+        self._method.getSynthStatus = getMethod(env, helper_class,
             "getSynthStatus", "()I")
-        self._method.setRate = env[0].GetMethodID(env, helper_class,
+        self._method.setRate = getMethod(env, helper_class,
             "setRate", "(F)V")
-        self._method.setPitch = env[0].GetMethodID(env, helper_class,
+        self._method.setPitch = getMethod(env, helper_class,
             "setPitch", "(F)V")
-        self._method.setLanguage = env[0].GetMethodID(env, helper_class,
+        self._method.setLanguage = getMethod(env, helper_class,
             "setLanguage", "(Ljava/lang/String;)I")
-        self._method.shutdown = env[0].GetMethodID(env, helper_class,
+        self._method.shutdown = getMethod(env, helper_class,
             "shutdown", "()V")
-        self._method.playFile = env[0].GetMethodID(env, helper_class,
+        self._method.playFile = getMethod(env, helper_class,
             "playFile", "(Ljava/lang/String;)I")
-        self._method.isPlaying = env[0].GetMethodID(env, helper_class,
+        self._method.isPlaying = getMethod(env, helper_class,
             "isPlaying", "()Z")
-        self._method.isPlaybackDone = env[0].GetMethodID(env, helper_class,
+        self._method.isPlaybackDone = getMethod(env, helper_class,
             "isPlaybackDone", "()Z")
-        self._method.stopPlayback = env[0].GetMethodID(env, helper_class,
+        self._method.stopPlayback = getMethod(env, helper_class,
             "stopPlayback", "()V")
-        self._method.pausePlayback = env[0].GetMethodID(env, helper_class,
+        self._method.pausePlayback = getMethod(env, helper_class,
             "pausePlayback", "()V")
-        self._method.resumePlayback = env[0].GetMethodID(env, helper_class,
+        self._method.resumePlayback = getMethod(env, helper_class,
             "resumePlayback", "()V")
         -- Pipeline methods (synth-then-play with audio focus)
-        self._method.synthesizeAndPlay = env[0].GetMethodID(env, helper_class,
+        self._method.synthesizeAndPlay = getMethod(env, helper_class,
             "synthesizeAndPlay", "(Ljava/lang/String;Ljava/lang/String;)I")
-        self._method.getPipelineStatus = env[0].GetMethodID(env, helper_class,
+        self._method.getPipelineStatus = getMethod(env, helper_class,
             "getPipelineStatus", "()I")
-        self._method.getPipelineDurationMs = env[0].GetMethodID(env, helper_class,
+        self._method.getPipelineDurationMs = getMethod(env, helper_class,
             "getPipelineDurationMs", "()I")
-        self._method.stopPipeline = env[0].GetMethodID(env, helper_class,
+        self._method.stopPipeline = getMethod(env, helper_class,
             "stopPipeline", "()V")
-        self._method.getDefaultEngine = env[0].GetMethodID(env, helper_class,
+        self._method.getDefaultEngine = getMethod(env, helper_class,
             "getDefaultEngine", "()Ljava/lang/String;")
 
-        if checkException(env) then
-            logger.err("AndroidTts: Failed to resolve one or more method IDs")
+        if not self._method.getInitStatus
+            or not self._method.playFile
+            or not self._method.isPlaying then
+            logger.err("AndroidTts: Failed to resolve required method IDs")
             env[0].DeleteLocalRef(env, helper_obj)
             env[0].DeleteLocalRef(env, helper_class)
             return
         end
+
+        -- Optional methods (newer tts_helper.dex).  Nil when absent — never
+        -- leave a NULL jmethodID in the table (LuaJIT NULL is truthy).
+        self._method.seekToMs = getMethod(env, helper_class,
+            "seekToMs", "(I)V")
+        self._method.playMediaFile = getMethod(env, helper_class,
+            "playMediaFile", "(Ljava/lang/String;)I")
 
         -- 6. Promote to GlobalRefs so they survive beyond this JNI context
         self._helper_ref = env[0].NewGlobalRef(env, helper_obj)
@@ -420,6 +470,16 @@ function AndroidTts:setLanguage(lang)
     end)
 end
 
+--- True when the loaded dex exposes playMediaFile (newer builds).
+function AndroidTts:hasPlayMediaFile()
+    return self._method.playMediaFile ~= nil
+end
+
+--- True when the loaded dex exposes seekToMs (newer builds).
+function AndroidTts:hasSeekToMs()
+    return self._method.seekToMs ~= nil
+end
+
 --[[--
 Play a WAV file through Android's MediaPlayer.
 @param path string  WAV file path
@@ -436,6 +496,27 @@ function AndroidTts:playFile(path)
         env[0].DeleteLocalRef(env, j_path)
         if checkException(env) then
             logger.err("AndroidTts: playFile threw exception")
+            return -1
+        end
+        return result
+    end)
+end
+
+--- Play a pre-recorded audiobook file (mp3/m4b) via the media audio stream.
+function AndroidTts:playMediaFile(path)
+    if not self._initialized or not self._helper_ref then return -1 end
+    if not self._method.playMediaFile then
+        return self:playFile(path)
+    end
+    local android = self._android
+    return android.jni:context(android.app.activity.vm, function(jni)
+        local env = jni.env
+        local j_path = env[0].NewStringUTF(env, path)
+        local result = env[0].CallIntMethod(env,
+            self._helper_ref, self._method.playMediaFile, j_path)
+        env[0].DeleteLocalRef(env, j_path)
+        if checkException(env) then
+            logger.err("AndroidTts: playMediaFile threw exception")
             return -1
         end
         return result
@@ -506,6 +587,21 @@ function AndroidTts:resumePlayback()
     android.jni:context(android.app.activity.vm, function(jni)
         jni.env[0].CallVoidMethod(jni.env,
             self._helper_ref, self._method.resumePlayback)
+    end)
+end
+
+--- Seek active MediaPlayer playback (ms). Requires tts_helper.dex with seekToMs.
+function AndroidTts:seekToMs(msec)
+    if not self._initialized or not self._helper_ref then return end
+    if not self._method.seekToMs then return end
+    msec = math.floor(tonumber(msec) or 0)
+    local android = self._android
+    android.jni:context(android.app.activity.vm, function(jni)
+        local env = jni.env
+        local args = ffi.new("jvalue[1]")
+        args[0].i = msec
+        env[0].CallVoidMethodA(env,
+            self._helper_ref, self._method.seekToMs, args)
     end)
 end
 

--- a/bugreport.lua
+++ b/bugreport.lua
@@ -194,6 +194,8 @@ local function collectPluginInfo(plugin)
         -- so the bundled-binary fields alone make a working setup look
         -- broken (issue #44).  Report the JNI bridge explicitly.
         if Device:isAndroid() then
+            local dex_path = (engine.plugin_dir or _utils_dir:sub(1, -2)) .. "/android/tts_helper.dex"
+            info.has_tts_helper_dex = fileExists(dex_path) and "yes" or "no"
             info.android_tts_bridge = engine._android_tts and "loaded" or "not loaded"
             if engine._android_tts then
                 local ok_st, st = pcall(function() return engine._android_tts:getInitStatus() end)
@@ -225,6 +227,19 @@ local function collectPluginInfo(plugin)
             if info.bt_hci0_address == "" then info.bt_hci0_address = "empty" end
         else
             info.bt_hci0_address = "missing"
+        end
+    end
+
+    -- MediaEngine backend (EPUB overlay / audiobook file playback)
+    local meng = plugin and plugin.media_engine
+    if meng then
+        info.media_backend = meng.backend or "nil (none detected)"
+        info.media_backend_cmd = meng.backend_cmd and sanitizePath(meng.backend_cmd) or "nil"
+        info.media_backend_error = meng.backend_error or "none"
+        if Device:isAndroid() then
+            info.media_android_bridge = (meng._android_player and "player-jni")
+                or (meng._android_tts and "tts-dex")
+                or "not loaded"
         end
     end
 

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -1331,7 +1331,10 @@ function MediaEngine:_playAndroid(gen)
         self.current_duration = dur_ms / 1000
     end
 
-    self._android_playback_confirmed = true
+    self._android_playback_confirmed = false
+    -- Small BT/output chain lag; sync loop subtracts this from position.
+    self.position_latency_s = 0.15
+
     logger.warn("MediaEngine: Android play", self.current_path,
         "offset=", offset, "duration=", self.current_duration)
 
@@ -1354,22 +1357,26 @@ function MediaEngine:_startAndroidCompletionWatcher(gen)
         end
         poll_count = poll_count + 1
         if poll_count == 15 and not self._android_playback_confirmed then
-            -- Only fail if MediaPlayer never produced a progressing position.
-            local pos_ms = player:getPositionMs() or 0
-            local start_ms = math.floor((self._seek_offset or 0) * 1000)
-            if pos_ms <= start_ms + 100 then
-                logger.err("MediaEngine: Android playback failed to start")
-                self.is_playing = false
-                if self._on_fail then
-                    local cb = self._on_fail
-                    self._on_fail = nil
-                    cb("android playback failed to start")
+            if player._ever_confirmed_playing or player._audio_started then
+                self._android_playback_confirmed = true
+            else
+                -- Only fail if MediaPlayer never produced a progressing position.
+                local pos_ms = player:getPositionMs() or 0
+                local start_ms = math.floor((self._seek_offset or 0) * 1000)
+                if pos_ms <= start_ms + 100 then
+                    logger.err("MediaEngine: Android playback failed to start")
+                    self.is_playing = false
+                    if self._on_fail then
+                        local cb = self._on_fail
+                        self._on_fail = nil
+                        cb("android playback failed to start")
+                    end
+                    return
                 end
-                return
+                self._android_playback_confirmed = true
             end
-            self._android_playback_confirmed = true
         end
-        if player:isPlaying() then
+        if player:isPlaying() or player._ever_confirmed_playing then
             self._android_playback_confirmed = true
         end
         if player:isPlaybackDone() then
@@ -3216,6 +3223,14 @@ function MediaEngine:getPosition()
     -- Kindle A2DP pause-halt: pipeline is gone; hold the saved pause position.
     if self.is_paused and self._paused_position ~= nil then
         return self._paused_position
+    end
+
+    -- Android: MediaPlayer position (startup hold + MP re-anchor in AndroidPlayer).
+    if self.backend == self.BACKENDS.ANDROID and self._android_player then
+        local pos_ms = self._android_player:getPositionMs()
+        if pos_ms then
+            return pos_ms / 1000
+        end
     end
 
     -- ffmpeg -progress backed position (EPUB read-along path): anchored to the

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -28,6 +28,7 @@ MediaEngine.BACKENDS = {
     WAV_PLAY = "wav-play",
     KINDLE_LIPC = "kindle-lipc",
     KINDLE_GST_PLAY = "kindle-gst-play",
+    ANDROID = "android",
 }
 
 function MediaEngine:new(o)
@@ -384,6 +385,11 @@ Windows zip extractors; rename .bin back to the original name if needed.
 @return string|nil  absolute path to ffmpeg binary, or nil
 --]]
 function MediaEngine:_findFfmpeg()
+    -- Bundled ffmpeg is a glibc Linux binary. Spawning it on Android (Bionic)
+    -- hard-crashes KOReader — never touch it on this platform.
+    if Device.isAndroid and Device:isAndroid() then
+        return nil
+    end
     if self._plugin_dir then
         local plugin_ffmpeg = self._plugin_dir .. "/bin/ffmpeg"
         -- Release zip ships ffmpeg as ffmpeg.bin; rename on first use.
@@ -419,7 +425,80 @@ function MediaEngine:_findFfmpeg()
 end
 
 function MediaEngine:_getTempDir()
+    if Device.isAndroid and Device:isAndroid() then
+        -- Prefer Android app cache. Never use /tmp on Android — often not
+        -- writable for the KOReader sandbox.
+        if self._android_cache_dir then
+            return self._android_cache_dir
+        end
+        local ok, android = pcall(require, "android")
+        if ok and android then
+            local cache = android.jni:context(android.app.activity.vm, function(jni)
+                local cache_file = jni:callObjectMethod(
+                    android.app.activity.clazz,
+                    "getCacheDir",
+                    "()Ljava/io/File;"
+                )
+                if cache_file == nil then return nil end
+                local abs_path = jni:callObjectMethod(
+                    cache_file, "getAbsolutePath", "()Ljava/lang/String;"
+                )
+                jni.env[0].DeleteLocalRef(jni.env, cache_file)
+                if abs_path == nil then return nil end
+                local result = jni:to_string(abs_path)
+                jni.env[0].DeleteLocalRef(jni.env, abs_path)
+                return result
+            end)
+            if cache then
+                self._android_cache_dir = cache .. "/audiobook"
+                os.execute('mkdir -p "' .. self._android_cache_dir .. '"')
+                return self._android_cache_dir
+            end
+        end
+    end
     return os.getenv("TMPDIR") or "/tmp"
+end
+
+--- Direct MediaPlayer via JNI (no dex, no ffmpeg). Preferred for EPUB overlays.
+function MediaEngine:_ensureAndroidPlayer()
+    if self._android_player then return self._android_player end
+    if not (Device.isAndroid and Device:isAndroid()) then return nil end
+    local ok, AndroidPlayer = pcall(dofile, self._plugin_dir .. "/androidplayer.lua")
+    if not ok or not AndroidPlayer then
+        logger.err("MediaEngine: androidplayer.lua failed:", AndroidPlayer)
+        return nil
+    end
+    local player = AndroidPlayer:new()
+    if player:init() then
+        self._android_player = player
+        return player
+    end
+    return nil
+end
+
+--- Reuse the plugin's AndroidTts bridge (shared with TTSEngine when available).
+--- Kept for TTS sentence playback only — audiobooks use AndroidPlayer.
+function MediaEngine:_ensureAndroidTts()
+    if self._android_tts then return self._android_tts end
+    local plugin = self.plugin
+    if plugin and plugin.tts_engine and plugin.tts_engine._android_tts then
+        self._android_tts = plugin.tts_engine._android_tts
+        return self._android_tts
+    end
+    local ok, AndroidTts = pcall(dofile, self._plugin_dir .. "/androidtts.lua")
+    if not ok or not AndroidTts then return nil end
+    local atts = AndroidTts:new{ plugin_dir = self._plugin_dir }
+    if atts:init() then
+        self._android_tts = atts
+        return atts
+    end
+    return nil
+end
+
+function MediaEngine:_fileExists(path)
+    local f = io.open(path, "r")
+    if f then f:close() return true end
+    return false
 end
 
 function MediaEngine:_nextGeneration()
@@ -467,7 +546,25 @@ function MediaEngine:detectBackend()
         return self.backend, self.backend_cmd
     end
 
-    -- 3) Kindle backends FIRST on Kindle hardware: there is no ALSA and no
+    -- 3) Android: direct MediaPlayer via JNI (Boox / KOReader Android).
+    -- Never fall through to ffmpeg-pipe: the bundled glibc ffmpeg SIGSEGVs
+    -- under Android Bionic, and aplay does not exist.
+    if Device.isAndroid and Device:isAndroid() then
+        local player = self:_ensureAndroidPlayer()
+        if player then
+            self.backend = self.BACKENDS.ANDROID
+            self.backend_cmd = "android-mediaplayer"
+            logger.warn("MediaEngine: selected Android MediaPlayer backend (direct JNI)")
+            return self.backend, self.backend_cmd
+        end
+        self.backend_error = _(
+            "Android audio playback is unavailable.\n\n" ..
+            "Could not initialize the system MediaPlayer. Restart KOReader and try again.")
+        logger.err("MediaEngine: Android MediaPlayer unavailable; refusing CLI fallbacks")
+        return nil, nil
+    end
+
+    -- 4) Kindle backends FIRST on Kindle hardware: there is no ALSA and no
     -- aplay, so the ffmpeg-pipe backend (which pipes WAV to aplay) can
     -- never produce sound here; audio must go through Amazon's
     -- mixersink → audiomgrd → BT pipeline.  The kindle-gst-play backend
@@ -740,6 +837,9 @@ end
 -- ---------------------------------------------------------------------------
 
 function MediaEngine:_findFfprobe()
+    if Device.isAndroid and Device:isAndroid() then
+        return nil
+    end
     -- Check bundled binary first (release zip may ship it as ffprobe.bin).
     if self._plugin_dir then
         local plugin_ffprobe = self._plugin_dir .. "/bin/ffprobe"
@@ -1062,41 +1162,59 @@ function MediaEngine:play(on_complete, on_fail)
     local gen = self:_nextGeneration()
     self._on_complete = on_complete
     self._on_fail = on_fail
-    self.is_playing = true
+    self.is_playing = false
     self.is_paused = false
-    -- Reset elapsed-time tracking
-    self._play_start_time = UIManager:getTime()
-    self._pause_start_time = nil
-    self._total_pause_ms = 0
+    self._android_playback_confirmed = false
 
     if self._use_persistent_pipeline then
         local ok = self:_playPersistentPipeline(gen)
-        if ok then return true end
+        if ok then
+            self.is_playing = true
+            self._play_start_time = UIManager:getTime()
+            self._pause_start_time = nil
+            self._total_pause_ms = 0
+            return true
+        end
         logger.warn("MediaEngine: persistent pipeline play failed, falling back to standard backend")
         self._use_persistent_pipeline = false
     end
 
+    local ok = false
     if self.backend == self.BACKENDS.MPV then
-        return self:_playMpv(gen)
+        ok = self:_playMpv(gen)
     elseif self.backend == self.BACKENDS.MPLAYER then
-        return self:_playMplayer(gen)
+        ok = self:_playMplayer(gen)
     elseif self.backend == self.BACKENDS.FFMPEG_PIPE then
-        return self:_playFfmpegPipe(gen)
+        ok = self:_playFfmpegPipe(gen)
     elseif self.backend == self.BACKENDS.GST_PLAY then
-        return self:_playGstPlay(gen)
+        ok = self:_playGstPlay(gen)
     elseif self.backend == self.BACKENDS.GST_PIPELINE then
-        return self:_playGstPipeline(gen)
+        ok = self:_playGstPipeline(gen)
     elseif self.backend == self.BACKENDS.APLAY or self.backend == self.BACKENDS.WAV_PLAY then
-        return self:_playAplay(gen)
+        ok = self:_playAplay(gen)
     elseif self.backend == self.BACKENDS.KINDLE_GST_PLAY then
-        return self:_playKindleGstPlay(gen)
+        ok = self:_playKindleGstPlay(gen)
     elseif self.backend == self.BACKENDS.KINDLE_LIPC then
-        return self:_playKindleLipc(gen)
+        ok = self:_playKindleLipc(gen)
+    elseif self.backend == self.BACKENDS.ANDROID then
+        ok = self:_playAndroid(gen)
+    else
+        logger.err("MediaEngine: unknown backend", self.backend)
+        if on_fail then on_fail("unknown backend") end
+        return false
     end
 
-    logger.err("MediaEngine: unknown backend", self.backend)
-    if on_fail then on_fail("unknown backend") end
-    return false
+    if ok then
+        self.is_playing = true
+        self.is_paused = false
+        self._play_start_time = UIManager:getTime()
+        self._pause_start_time = nil
+        self._total_pause_ms = 0
+    else
+        self.is_playing = false
+        self.is_paused = false
+    end
+    return ok
 end
 
 --[[--
@@ -1183,6 +1301,101 @@ function MediaEngine:_spawnTracked(cmd, gen, opts)
     end)
 
     return true
+end
+
+-- ---------------------------------------------------------------------------
+-- Android MediaPlayer playback (Boox, KOReader Android)
+-- ---------------------------------------------------------------------------
+
+function MediaEngine:_playAndroid(gen)
+    local player = self:_ensureAndroidPlayer()
+    if not player then
+        logger.err("MediaEngine: Android MediaPlayer unavailable")
+        if self._on_fail then self._on_fail("android mediaplayer unavailable") end
+        return false
+    end
+
+    pcall(function() player:stop() end)
+
+    local offset = self._seek_offset or 0
+    local seek_ms = math.floor(offset * 1000)
+    local ok = player:play(self.current_path, seek_ms)
+    if not ok then
+        logger.err("MediaEngine: Android play failed for", self.current_path)
+        if self._on_fail then self._on_fail("android playback failed") end
+        return false
+    end
+
+    local dur_ms = player:getDurationMs()
+    if dur_ms and dur_ms > 0 then
+        self.current_duration = dur_ms / 1000
+    end
+
+    self._android_playback_confirmed = true
+    logger.warn("MediaEngine: Android play", self.current_path,
+        "offset=", offset, "duration=", self.current_duration)
+
+    self:_startAndroidCompletionWatcher(gen)
+    return true
+end
+
+function MediaEngine:_startAndroidCompletionWatcher(gen)
+    local player = self._android_player
+    if not player then return end
+    local poll_count = 0
+    local max_polls = math.max(600,
+        math.floor((self.current_duration or 300) * 10))
+    local function poll()
+        if self.play_generation ~= gen then return end
+        if not self.is_playing then return end
+        if self.is_paused then
+            UIManager:scheduleIn(0.25, poll)
+            return
+        end
+        poll_count = poll_count + 1
+        if poll_count == 15 and not self._android_playback_confirmed then
+            -- Only fail if MediaPlayer never produced a progressing position.
+            local pos_ms = player:getPositionMs() or 0
+            local start_ms = math.floor((self._seek_offset or 0) * 1000)
+            if pos_ms <= start_ms + 100 then
+                logger.err("MediaEngine: Android playback failed to start")
+                self.is_playing = false
+                if self._on_fail then
+                    local cb = self._on_fail
+                    self._on_fail = nil
+                    cb("android playback failed to start")
+                end
+                return
+            end
+            self._android_playback_confirmed = true
+        end
+        if player:isPlaying() then
+            self._android_playback_confirmed = true
+        end
+        if player:isPlaybackDone() then
+            self.is_playing = false
+            self.is_paused = false
+            if self._on_complete then
+                local cb = self._on_complete
+                self._on_complete = nil
+                cb()
+            end
+            return
+        end
+        if poll_count >= max_polls then
+            logger.warn("MediaEngine: Android playback timed out")
+            pcall(function() player:stop() end)
+            self.is_playing = false
+            if self._on_fail then
+                local cb = self._on_fail
+                self._on_fail = nil
+                cb("android playback timeout")
+            end
+            return
+        end
+        UIManager:scheduleIn(0.2, poll)
+    end
+    UIManager:scheduleIn(0.4, poll)
 end
 
 function MediaEngine:_playMpv(gen)
@@ -2415,7 +2628,7 @@ function MediaEngine:_startCompletionWatcher(gen)
         -- wrapper shell lives until gst-launch finishes actual playout).
         if (self.backend == self.BACKENDS.APLAY or self.backend == self.BACKENDS.WAV_PLAY
             or self.backend == self.BACKENDS.GST_PLAY or self.backend == self.BACKENDS.GST_PIPELINE
-            or self.backend == self.BACKENDS.KINDLE_GST_PLAY)
+            or self.backend == self.BACKENDS.KINDLE_GST_PLAY or self.backend == self.BACKENDS.ANDROID)
             and not self._use_progress_position
             and self._play_start_time and self.current_duration then
             local pos = self:getPosition()
@@ -2455,6 +2668,11 @@ function MediaEngine:pause()
         local pf = io.open(self._media_ctrl_dir .. "/pause", "w")
         if pf then pf:write("1"); pf:close() end
         logger.warn("MediaEngine: paused persistent pipeline (ffmpeg feeder), wrapper=", self._pipeline_wrapper_pid)
+        return
+    end
+
+    if self.backend == self.BACKENDS.ANDROID and self._android_player then
+        self._android_player:pause()
         return
     end
 
@@ -2525,6 +2743,16 @@ function MediaEngine:resume()
             f:close()
         end
         logger.warn("MediaEngine: resumed persistent pipeline at", resume_pos, "wrapper=", self._pipeline_wrapper_pid)
+        return
+    end
+
+    if self.backend == self.BACKENDS.ANDROID and self._android_player then
+        self.is_paused = false
+        if self._pause_start_time then
+            self._total_pause_ms = self._total_pause_ms + time.to_ms(UIManager:getTime() - self._pause_start_time)
+            self._pause_start_time = nil
+        end
+        self._android_player:resume()
         return
     end
 
@@ -2606,6 +2834,10 @@ function MediaEngine:stop()
     if self._position_timer then
         UIManager:unschedule(self._position_timer)
         self._position_timer = nil
+    end
+
+    if self.backend == self.BACKENDS.ANDROID and self._android_player then
+        pcall(function() self._android_player:stop() end)
     end
 
     if self._persistent_pipeline_active then
@@ -2722,6 +2954,27 @@ function MediaEngine:seek(seconds, mode)
     -- paused after a seek.  is_playing stays true when paused; is_paused is
     -- the real indicator.
     local was_playing = self.is_playing and not self.is_paused
+
+    if self.backend == self.BACKENDS.ANDROID then
+        local target = seconds
+        if mode == "relative" then
+            target = self:getPosition() + seconds
+        end
+        target = math.max(0, target)
+        self._seek_offset = target
+        if self.is_paused then
+            self._paused_position = target
+            return true
+        end
+        local player = self._android_player
+        if player then
+            player:seekToMs(math.floor(target * 1000))
+            self._play_start_time = UIManager:getTime()
+            self._total_pause_ms = 0
+            return true
+        end
+        return false
+    end
 
     if self.backend == self.BACKENDS.MPV then
         local mode_str = mode == "relative" and "relative" or "absolute"
@@ -2989,7 +3242,11 @@ function MediaEngine:getPosition()
         -- else: fall through to wall-clock below
     end
 
-    -- For backends without IPC (gst-play, aplay, ffmpeg-pipe), estimate from elapsed time.
+    -- Android: use the same wall-clock path as other non-IPC backends.
+    -- Do NOT trust MediaPlayer.getCurrentPosition() alone via JNI (often
+    -- stuck at 0 on Boox).  MediaEngine._play_start_time is real wall time.
+
+    -- For backends without IPC (gst-play, aplay, ffmpeg-pipe, android), estimate from elapsed time.
     -- Scale elapsed real time by playback speed so the reported position tracks the
     -- actual audio position when atempo / speed filters are in use.
     if self._play_start_time then

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -1332,8 +1332,10 @@ function MediaEngine:_playAndroid(gen)
     end
 
     self._android_playback_confirmed = false
-    -- Small BT/output chain lag; sync loop subtracts this from position.
-    self.position_latency_s = 0.15
+    -- Output / BT chain lag subtracted by MediaSync highlight loop.
+    -- Wall-clock is locked once at audible start; this small latency keeps
+    -- highlights from leading the spoken audio on Boox.
+    self.position_latency_s = 0.25
 
     logger.warn("MediaEngine: Android play", self.current_path,
         "offset=", offset, "duration=", self.current_duration)

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -673,6 +673,10 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
     if not self.media_engine:load(audio_path) then
         logger.err("MediaSync: failed to load audio", audio_path)
         self.state = self.STATE.STOPPED
+        local err = self.media_engine and self.media_engine.backend_error
+        if err then
+            UIManager:show(InfoMessage:new{ text = err, timeout = 8 })
+        end
         return false
     end
 
@@ -1530,8 +1534,15 @@ function MediaSync:_startPositionPoller(gen)
         end
 
         -- Update progress bar
-        if dur and dur > 0 and pos then
-            local pct = math.floor((pos / dur) * 100)
+        local bar_pos, bar_dur = pos, dur
+        if self.overlay_mode then
+            local ch_pos, ch_dur = self:_overlayChapterProgress(pos)
+            if ch_pos and ch_dur and ch_dur > 0 then
+                bar_pos, bar_dur = ch_pos, ch_dur
+            end
+        end
+        if bar_dur and bar_dur > 0 and bar_pos then
+            local pct = math.floor((bar_pos / bar_dur) * 100)
             if pct ~= self._last_progress_pct then
                 self._last_progress_pct = pct
                 if self.playback_bar then
@@ -1544,8 +1555,9 @@ function MediaSync:_startPositionPoller(gen)
 
         -- Update time display
         if self.playback_bar then
+            local display_pos, display_dur = bar_pos or 0, bar_dur or 0
             pcall(function()
-                self.playback_bar:updateTimeDisplay(pos or 0, dur or 0)
+                self.playback_bar:updateTimeDisplay(display_pos, display_dur)
             end)
             -- Update chapter title (overlay: SMIL chapter across audio parts)
             local ok_ch, ch, ch_idx = pcall(function() return self:getCurrentChapter() end)
@@ -2220,6 +2232,94 @@ function MediaSync:getCurrentChapter()
         end
     end
     return self.chapters[1], 1
+end
+
+--- Position/duration within the current SMIL chapter (seconds).
+--- A Storyteller chapter (content document) can span several ~5 min audio
+--- parts; sum those segments so the scrubber shows the full chapter.
+function MediaSync:_overlayChapterProgress(pos)
+    pos = tonumber(pos) or 0
+    local ch, idx = self:_resolveOverlayChapter()
+    if not ch then return nil, nil end
+
+    local chapters = self.plugin and self.plugin._smil_overlay_chapters
+    if not chapters or #chapters == 0 then return nil, nil end
+
+    local key = ch.text_doc or ch.title
+    if not key then return nil, nil end
+
+    -- Collect every overlay-chapter row that belongs to this content chapter,
+    -- in playlist/audio order.
+    local segments = {}
+    for i, c in ipairs(chapters) do
+        local ckey = c.text_doc or c.title
+        if ckey == key then
+            local start_t = tonumber(c.start_time) or 0
+            local end_t = nil
+            -- End = next chapter boundary on the same audio file…
+            for j = i + 1, #chapters do
+                if chapters[j].audio_path == c.audio_path then
+                    end_t = tonumber(chapters[j].start_time)
+                    break
+                end
+            end
+            -- …or last timing entry for this doc on that file.
+            if not end_t then
+                local by_file = self.plugin and self.plugin._smil_by_file
+                local slot = by_file and c.audio_path and by_file[c.audio_path]
+                local timing = (slot and slot.timing) or self.timing_data
+                if timing then
+                    for k = #timing, 1, -1 do
+                        local e = timing[k]
+                        if (not c.text_doc or e.text_doc == c.text_doc)
+                            and (not e.audio_path or e.audio_path == c.audio_path) then
+                            end_t = tonumber(e.end_time) or tonumber(e.start_time)
+                            break
+                        end
+                    end
+                end
+            end
+            if not end_t then
+                end_t = start_t + 1
+            end
+            table.insert(segments, {
+                audio_path = c.audio_path,
+                start_time = start_t,
+                end_time = end_t,
+                dur = math.max(0.1, end_t - start_t),
+                idx = i,
+            })
+        end
+    end
+    if #segments == 0 then return nil, nil end
+
+    local total = 0
+    for _, s in ipairs(segments) do total = total + s.dur end
+
+    local current_path = self.media_engine and self.media_engine.current_path
+    local path_order = {}
+    if self.playlist_files then
+        for pi, f in ipairs(self.playlist_files) do
+            path_order[f.path] = pi
+        end
+    end
+    local cur_order = (current_path and path_order[current_path]) or 0
+
+    local ch_pos = 0
+    for _, s in ipairs(segments) do
+        local seg_order = (s.audio_path and path_order[s.audio_path]) or 0
+        if s.audio_path == current_path then
+            ch_pos = ch_pos + math.max(0, math.min(pos - s.start_time, s.dur))
+            break
+        elseif seg_order > 0 and cur_order > 0 and seg_order < cur_order then
+            ch_pos = ch_pos + s.dur
+        elseif cur_order == 0 and s.idx < (idx or 1) then
+            ch_pos = ch_pos + s.dur
+        end
+    end
+
+    ch_pos = math.max(0, math.min(ch_pos, total))
+    return ch_pos, total
 end
 
 return MediaSync

--- a/ttsengine.lua
+++ b/ttsengine.lua
@@ -332,25 +332,17 @@ function TTSEngine:detectBackend()
     end
     -- Log what we searched for
     logger.warn("TTSEngine: No TTS backend found. Searched for: espeak-ng, espeak, pico2wave, flite, festival")
-    -- On Android, try the native TextToSpeech API via JNI
+    -- On Android, select the system TTS backend but DO NOT load the helper
+    -- .dex / TextToSpeech engine here.  DexClassLoader + TTS binder init at
+    -- document-open time hard-crashes KOReader on some Boox devices (Go 10.3).
+    -- Real init happens lazily in _ensureAndroidTts() on first speak().
+    -- EPUB Media Overlay playback uses AndroidPlayer and never needs this.
     if is_android then
-        local atts = AndroidTts:new{
-            plugin_dir = self.plugin_dir or ".",
-        }
-        if atts:init() then
-            -- Wait up to 3 seconds for the TTS engine to initialize
-            if atts:waitForInit(3000) then
-                self._android_tts = atts
-                self.backend = self.BACKENDS.ANDROID
-                logger.dbg("TTSEngine: Using Android TTS backend")
-                return
-            else
-                atts:shutdown()
-                logger.warn("TTSEngine: Android TTS init timed out or failed")
-            end
-        else
-            logger.warn("TTSEngine: Android TTS helper .dex not available at", Utils.normalizeDirPath(self.plugin_dir or "."))
-        end
+        self.backend = self.BACKENDS.ANDROID
+        self._android_tts = nil
+        self._android_tts_deferred = true
+        logger.warn("TTSEngine: Android TTS selected (deferred init until first speak)")
+        return
     end
     -- Platform-native TTS: user-supplied helper that drives a device-native,
     -- licensed engine (e.g. PocketBook ReadSpeaker).  This is a last-resort
@@ -1381,8 +1373,39 @@ function TTSEngine:_androidPcmActive()
     return self.plugin and self.plugin:getSetting("android_pcm_stream", false) or false
 end
 
+--- Lazy-load AndroidTts (dex + TextToSpeech). Safe to call repeatedly.
+--- @return table|nil AndroidTts instance, or nil on failure
+function TTSEngine:_ensureAndroidTts()
+    if self._android_tts then return self._android_tts end
+    if self._android_tts_failed then return nil end
+
+    local atts = AndroidTts:new{
+        plugin_dir = self.plugin_dir or ".",
+    }
+    local ok, err = pcall(function()
+        if not atts:init() then
+            error("AndroidTts:init returned false")
+        end
+        if not atts:waitForInit(3000) then
+            atts:shutdown()
+            error("AndroidTts:waitForInit failed")
+        end
+    end)
+    if not ok then
+        self._android_tts_failed = true
+        self._android_tts_deferred = false
+        logger.err("TTSEngine: Android TTS deferred init failed:", err)
+        return nil
+    end
+
+    self._android_tts = atts
+    self._android_tts_deferred = false
+    logger.warn("TTSEngine: Android TTS helper ready (lazy init)")
+    return atts
+end
+
 function TTSEngine:synthesizeAndroid(text, audio_file, callback)
-    local atts = self._android_tts
+    local atts = self:_ensureAndroidTts()
     if not atts then
         logger.err("TTSEngine: Android TTS not initialized")
         if callback then callback(false, nil) end


### PR DESCRIPTION
## Summary

Enables Storyteller EPUB3 Media Overlay read-aloud on **KOReader Android** (validated on Onyx Boox Go 10.3 Gen Ⅱ Lumi), where the previous path fell through to bundled glibc `ffmpeg` / `ffmpeg-pipe` and either produced no audio or hard-crashed the process.

### Why this was broken on Boox
- On Android, `MediaEngine` had no real audiobook backend. Playback attempted **bundled glibc `ffmpeg`** (SIGSEGV on Bionic) or wall-clock-only sync with **no audible output**.
- Result: SMIL loaded, pages turned chaotically, **no sound** on BT or speakers.
- Secondary crashes came from fragile `tts_helper.dex` / JNI paths (`io.open(..., "rb")`, NULL `GetMethodID` treated as truthy in LuaJIT, DexClassLoader + TTS binder at **document open**).

### What we changed
- **New `androidplayer.lua`**: direct `android.media.MediaPlayer` via JNI (USAGE_MEDIA), no dex and no ffmpeg for overlay chapters.
- **`mediaengine.lua`**: Android backend uses `AndroidPlayer`; never spawn/probe bundled ffmpeg on Android; pause/resume/seek/stop wired through; `getPosition()` reads the player.
- **Highlight sync (Boox-specific)**: `getCurrentPosition()` is flaky on this device (stuck or jittery). Final approach:
  1. brief hold at seek while audio buffers
  2. **one-shot** wall-clock lock when playback starts (or ~350 ms grace)
  3. thereafter **monotonic wall-clock only** (no continuous MP polling)
  4. small `position_latency_s` (~250 ms) so highlights do not lead speech
- **`ttsengine.lua`**: defer Android TTS dex/`TextToSpeech` init until first speak — loading it at EPUB open hard-crashed KOReader on Boox. Overlay playback does not need TTS.
- **`androidtts.lua` / `TtsHelper.java`**: safer dex loading; optional JNI methods; `playMediaFile` / `seekToMs` kept alongside upstream PCM-stream work.
- **`mediasync.lua`**: overlay chapter progress sums SMIL segments for full-chapter UI duration.
- **`bugreport.lua`**: reports `media_backend`, `media_android_bridge` (`player-jni` vs tts-dex), dex presence.
- Merged **upstream `v0.1.17.21`** (Android TTS persistent PCM stream, refs #44) into this branch.

### Version
`0.1.17.34` (plugin `_meta.lua`)

## Test plan

Device: **Onyx Boox Go 10.3 (Gen Ⅱ) Lumi**, KOReader **v2026.07.1**, Android 15  
Book: Storyteller EPUB3 (*Le Roi de fer* / Les Rois maudits readaloud)

- [x] Open EPUB3 with plugin installed — **no crash** (regression fixed by deferred TTS dex init)
- [x] **Play aligned audiobook from here** — audio plays (speakers and/or Bluetooth)
- [x] Timer / scrubber advances correctly
- [x] Sentence highlights track narration from cold start (no stop/restart required)
- [x] Stop + restart — highlights stay stable (no back-and-forth thrashing)
- [x] Plugin remains visible in Tools after deploy (lean deploy without glibc `bin/ffmpeg` on device)
- [ ] Optional: plain TTS “Read aloud from here” (lazy Android TTS init; separate from overlay path)
- [ ] Optional: Kindle / non-Android smoke — Android paths are gated; upstream PCM merge preserved

## Notes for reviewers
- Bundled `bin/ffmpeg` must **not** be executed on Android; `_findFfmpeg()` returns `nil` there. Prefer lean installs on Boox (Lua + `android/tts_helper.dex`) to avoid accidental exec / storage bloat.
- Overlay audio uses **MediaPlayer JNI** (`media_android_bridge=player-jni` in bug reports). TTS still uses dex when first speak happens.
- If highlights are consistently early/late on a given BT headset, tune **SMIL sync offset** or `position_latency_s` slightly.

## Related
- Upstream Android TTS PCM: #44 / `v0.1.17.21`
- Storyteller overlay baseline: #51