### PR TITLE
android: keep overlay Play/Pause and AirPods stem in sync with SMIL playback

### DIFF
--- a/androidmediasession.lua
+++ b/androidmediasession.lua
@@ -278,12 +278,12 @@ function AndroidMediaSession:startPolling(plugin)
                 self._last_dispatch_time = now
                 logger.warn("AndroidMediaSession: command", cmd)
                 local p = self._plugin
-                if cmd == self.CMD_PLAY_PAUSE then
+                -- AirPods Pro stem AVRCP often repeats KEYCODE_MEDIA_PAUSE for
+                -- both clicks (never PLAY).  Honor the plugin's real state.
+                if cmd == self.CMD_PLAY_PAUSE
+                    or cmd == self.CMD_PLAY
+                    or cmd == self.CMD_PAUSE then
                     pcall(function() p:onMediaPlayPause() end)
-                elseif cmd == self.CMD_PLAY then
-                    pcall(function() p:onMediaPlay() end)
-                elseif cmd == self.CMD_PAUSE then
-                    pcall(function() p:onMediaPause() end)
                 elseif cmd == self.CMD_STOP then
                     pcall(function() p:onMediaStop() end)
                 elseif cmd == self.CMD_NEXT then

--- a/btmediacontrol.lua
+++ b/btmediacontrol.lua
@@ -106,7 +106,14 @@ end
 --- Android MediaSession path (AirPods stem / BT headset buttons on Boox).
 function BtMediaControl._startAndroidMediaSession(plugin)
     if BtMediaControl._android_session then
-        BtMediaControl._android_session:startPolling(plugin)
+        local session = BtMediaControl._android_session
+        session:startPolling(plugin)
+        -- stopSession() keeps the Lua wrapper but releases the Java session.
+        -- Re-activate so AirPods stem events reach us after a previous stop.
+        if not BtMediaControl._android_session_started then
+            session:startSession("Audiobook", "")
+            BtMediaControl._android_session_started = true
+        end
         return true
     end
     local plugin_dir = (plugin and plugin.path) or "."
@@ -128,6 +135,7 @@ function BtMediaControl._startAndroidMediaSession(plugin)
     end
     BtMediaControl._android_session = session
     session:startSession("Audiobook", "")
+    BtMediaControl._android_session_started = true
     session:startPolling(plugin)
     logger.warn("BtMediaControl: Android MediaSession AVRCP active")
     return true

--- a/main.lua
+++ b/main.lua
@@ -3423,12 +3423,32 @@ end
 
 function Audiobook:onMediaPlay()
     if not self._init_ok then return true end
+    -- Some headsets send PLAY for every stem click.  If we are already
+    -- playing, treat it as pause rather than a no-op resume.
+    local media_playing = self.media_sync and self.media_sync.state == "playing"
+    local tts_playing = self.sync_controller and self.sync_controller.isPlaying
+        and self.sync_controller:isPlaying()
+    if media_playing or tts_playing then
+        logger.warn("Audiobook: headset PLAY while playing — pause")
+        self:pauseReadAlong()
+        return true
+    end
     self:resumeReadAlong()
     return true
 end
 
 function Audiobook:onMediaPause()
     if not self._init_ok then return true end
+    -- AirPods Pro stem often repeats KEYCODE_MEDIA_PAUSE instead of PLAY.
+    -- A second pause while already paused is the resume click.
+    local media_paused = self.media_sync and self.media_sync.state == "paused"
+    local tts_paused = self.sync_controller and self.sync_controller.isPaused
+        and self.sync_controller:isPaused()
+    if media_paused or tts_paused then
+        logger.warn("Audiobook: headset PAUSE while paused — resume")
+        self:resumeReadAlong()
+        return true
+    end
     self:pauseReadAlong()
     return true
 end

--- a/main.lua
+++ b/main.lua
@@ -3253,6 +3253,28 @@ function Audiobook:_ensureBtMediaControl()
     end
 end
 
+--- Re-take MediaSession audio focus after Android TTS speak() stole it.
+function Audiobook:notifyAudioPlaying()
+    self:_ensureBtMediaControl()
+    if not BtMediaControl then return end
+    local session = BtMediaControl.getAndroidSession and BtMediaControl.getAndroidSession()
+    if session and session.startSession then
+        session:startSession("Audiobook", "")
+        BtMediaControl._android_session_started = true
+        if session.setPlaying then
+            session:setPlaying(true, 0)
+        end
+        return
+    end
+    pcall(function() BtMediaControl.sendPlaybackStatus("playing") end)
+end
+
+--- Tell the headset the overlay is paused (stem maps HEADSETHOOK from PlaybackState).
+function Audiobook:notifyAudioPaused()
+    if not BtMediaControl then return end
+    pcall(function() BtMediaControl.sendPlaybackStatus("paused") end)
+end
+
 function Audiobook:pauseReadAlong()
     if not self._init_ok then return end
     -- Pause media playback if active

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -763,9 +763,7 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
     if opts.prepare_only then
         self._start_position = nil
         self.state = self.STATE.STOPPED
-        if self.playback_bar and self.playback_bar.setPlaying then
-            pcall(function() self.playback_bar:setPlaying(false) end)
-        end
+        self:_publishPlayState(false)
         logger.warn("MediaSync: prepared overlay session at", resume_pos)
         return true
     end
@@ -788,10 +786,33 @@ function MediaSync:start(audio_path, timing_data, chapters, cover_path, playlist
     self.state = self.STATE.PLAYING
     self:_startSyncLoop(gen)
     self:_startPositionPoller(gen)
+    -- Overlay pin / "play from here" reuse a bar that was showing Play, and
+    -- the mini-player pause path never went through pauseReadAlong — publish
+    -- both the icon and Android MediaSession (AirPods stem uses PlaybackState).
+    self:_publishPlayState(true)
 
     logger.warn("MediaSync: started playback, sentences=", self._total_sentences,
         "duration=", self.media_engine:getDuration())
     return true
+end
+
+--- Keep the mini-bar icon and BT/MediaSession PlaybackState in lockstep.
+-- Android maps AirPods HEADSETHOOK to play vs pause from that state; if it
+-- still says paused while audio is running, the stem becomes a no-op.
+function MediaSync:_publishPlayState(playing)
+    playing = playing and true or false
+    if self.playback_bar and self.playback_bar.setPlaying then
+        pcall(function() self.playback_bar:setPlaying(playing) end)
+    end
+    local plugin = self.plugin
+    if not plugin then return end
+    if playing then
+        if plugin.notifyAudioPlaying then
+            pcall(function() plugin:notifyAudioPlaying() end)
+        end
+    elseif plugin.notifyAudioPaused then
+        pcall(function() plugin:notifyAudioPaused() end)
+    end
 end
 
 --- @param keep_chapter_menu boolean|nil
@@ -834,9 +855,7 @@ function MediaSync:stop(keep_chapter_menu, opts)
         if keep_bar then
             -- Leave the mini player and reserved margins in place so CRE
             -- does not reflow the book on the next play (Android ANR).
-            if self.playback_bar and self.playback_bar.setPlaying then
-                pcall(function() self.playback_bar:setPlaying(false) end)
-            end
+            self:_publishPlayState(false)
         else
             if self.playback_bar then
                 pcall(function() self.playback_bar:hide() end)
@@ -1217,9 +1236,7 @@ function MediaSync:pause(auto)
     end
     -- Pin the SMIL highlight to the pause time immediately.
     pcall(function() self:_updateHighlightAtTime(pos) end)
-    if self.playback_bar then
-        pcall(function() self.playback_bar:setPlaying(false) end)
-    end
+    self:_publishPlayState(false)
     logger.warn("MediaSync: paused", auto and "(auto)" or "", "at", pos)
 end
 
@@ -1258,11 +1275,7 @@ function MediaSync:resume(auto)
     end
     -- Snap highlight to the SMIL sentence for this audio time before the loop.
     pcall(function() self:_updateHighlightAtTime(resume_pos) end)
-    if self.playback_bar then
-        pcall(function()
-            self.playback_bar:setPlaying(true)
-        end)
-    end
+    self:_publishPlayState(true)
     -- The sync loop self-terminates while paused: its tick bails out without
     -- rescheduling once state != PLAYING.  Restart it (and the position
     -- poller, for symmetry) so the highlight tracks the audio again instead of
@@ -2503,9 +2516,7 @@ function MediaSync:showPlaybackBar()
                 if ok then
                     self:_startSyncLoop(gen)
                     self:_startPositionPoller(gen)
-                    if self.playback_bar and self.playback_bar.setPlaying then
-                        pcall(function() self.playback_bar:setPlaying(true) end)
-                    end
+                    self:_publishPlayState(true)
                 else
                     self.state = self.STATE.STOPPED
                 end


### PR DESCRIPTION
## Summary
- After pinned overlay / **Play aligned audiobook from here**, audio and highlight started but the mini-bar stayed on **Play** because `MediaSync:start()` never flipped the reused bar (it was left showing Play from `prepare_only` / pause).
- The overlay pause/play path also skipped `pauseReadAlong` / `resumeReadAlong`, so Android **MediaSession PlaybackState** stayed paused. AirPods Pro 3 stem maps `HEADSETHOOK` from that state, so press became a no-op.
- One helper now publishes both the icon and MediaSession on start / pause / resume / keep-bar stop, and re-activates a Java session that `stopSession()` had released.
- Follow-up: AirPods Pro 3 AVRCP repeats `KEYCODE_MEDIA_PAUSE` for both stem clicks (never PLAY). Headset play/pause commands now toggle from the plugin's real state.

## Test plan
- [x] Boox + AirPods Pro 3: open a Storyteller EPUB (pinned overlay), **Play aligned audiobook from here** — mini-bar shows **Pause**, stem pause/resume works.
- [x] Pause from the mini-bar, then stem resume; pause from the stem, then mini-bar resume.
- [x] Close the player (session released), play from here again — stem still works.
- [ ] Kindle: no change expected for stem (no AVRCP); confirm the icon still toggles on play from here.

Verified 2026-08-21 on Onyx Boox Go 10.3 Lumi II (Android 15) with AirPods Pro 3. Kindle not retested this round.