### PR TITLE
smil: Storyteller read-along still works after a Readest/Calibre re-save

### DIFF
--- a/dev/test_epubmediaoverlay_multiline.lua
+++ b/dev/test_epubmediaoverlay_multiline.lua
@@ -17,7 +17,7 @@ local function escape_unzip_member(path)
 end
 
 local function url_decode(path)
-    if not path or not path:find("%%", 1, true) then
+    if not path or not path:find("%", 1, true) then
         return path
     end
     return (path:gsub("%%(%x%x)", function(hex)

--- a/dev/test_epubmediaoverlay_multiline.lua
+++ b/dev/test_epubmediaoverlay_multiline.lua
@@ -16,6 +16,15 @@ local function escape_unzip_member(path)
     return path:gsub("%[", "[[]")
 end
 
+local function url_decode(path)
+    if not path or not path:find("%%", 1, true) then
+        return path
+    end
+    return (path:gsub("%%(%x%x)", function(hex)
+        return string.char(tonumber(hex, 16))
+    end))
+end
+
 local function compact_xml(xml)
     return xml:gsub(">%s+<", "><")
 end
@@ -74,6 +83,18 @@ end
 local opf = read_file(fixtures .. "/content.opf")
 if not opf then
     table.insert(failures, "missing fixture content.opf")
+end
+
+local encoded = "MediaOverlays/005%20-%20PROLOGUE.smil"
+if url_decode(encoded) ~= "MediaOverlays/005 - PROLOGUE.smil" then
+    table.insert(failures, "url_decode spaces: " .. tostring(url_decode(encoded)))
+end
+local encoded_comma = "MediaOverlays/011%20-%20V%20LE%20ROI%2C%20SES.smil"
+if url_decode(encoded_comma) ~= "MediaOverlays/011 - V LE ROI, SES.smil" then
+    table.insert(failures, "url_decode comma: " .. tostring(url_decode(encoded_comma)))
+end
+if url_decode("MediaOverlays/plain.smil") ~= "MediaOverlays/plain.smil" then
+    table.insert(failures, "url_decode should leave plain paths alone")
 end
 
 local storyteller_member =

--- a/epubmediaoverlay.lua
+++ b/epubmediaoverlay.lua
@@ -54,6 +54,29 @@ function EpubMediaOverlay:_escapeUnzipMember(path)
     return path:gsub("%[", "[[]")
 end
 
+--- Calibre / Readest rewrite OPF hrefs as percent-encoded URLs
+-- (`MediaOverlays/005%20-%20PROLOGUE.smil`) while the zip members keep
+-- literal spaces.  unzip then misses every SMIL and we report "no
+-- built-in audiobook" even though Readest still plays the same file.
+function EpubMediaOverlay:_urlDecode(path)
+    if not path or not path:find("%%", 1, true) then
+        return path
+    end
+    return (path:gsub("%%(%x%x)", function(hex)
+        return string.char(tonumber(hex, 16))
+    end))
+end
+
+--- Zip member names to try: as written, then percent-decoded.
+function EpubMediaOverlay:_zipMemberCandidates(path)
+    local list = { path }
+    local decoded = self:_urlDecode(path)
+    if decoded and decoded ~= path then
+        list[#list + 1] = decoded
+    end
+    return list
+end
+
 --- Quote an argument for POSIX sh: single quotes make the whole string
 -- literal, with the standard '\'' escape for embedded quotes. Never build
 -- a shell command with double-quote-and-escape: $(), backticks and friends
@@ -200,18 +223,29 @@ end
 
 function EpubMediaOverlay:_extractFromZip(epub_path, internal_path)
     -- Extract a single file from the EPUB using unzip
-    if not self:_validateZipMember(internal_path) then
-        logger.warn("EpubMediaOverlay: refusing unsafe archive member path",
-            tostring(internal_path))
-        return nil
+    local last_unsafe
+    for _, path in ipairs(self:_zipMemberCandidates(internal_path)) do
+        if not self:_validateZipMember(path) then
+            last_unsafe = path
+        else
+            local zip_member = self:_escapeUnzipMember(path)
+            local cmd = string.format(
+                'unzip -p %s %s',
+                self:_quoteShell(epub_path),
+                self:_quoteShell(zip_member)
+            )
+            local out = self:_runCommand(cmd)
+            if out and out ~= ""
+                and not out:find("filename not matched", 1, true) then
+                return out
+            end
+        end
     end
-    local zip_member = self:_escapeUnzipMember(internal_path)
-    local cmd = string.format(
-        'unzip -p %s %s',
-        self:_quoteShell(epub_path),
-        self:_quoteShell(zip_member)
-    )
-    return self:_runCommand(cmd)
+    if last_unsafe then
+        logger.warn("EpubMediaOverlay: refusing unsafe archive member path",
+            tostring(last_unsafe))
+    end
+    return nil
 end
 
 function EpubMediaOverlay:_findOpfPath(epub_path)
@@ -264,7 +298,7 @@ function EpubMediaOverlay:_parseOpfManifest(opf_xml)
         if id and href then
             manifest_items[id] = {
                 id = id,
-                href = href,
+                href = self:_urlDecode(href) or href,
                 media_type = media_type,
                 media_overlay = media_overlay,
             }
@@ -333,6 +367,10 @@ function EpubMediaOverlay:_parseSmil(smil_xml, smil_base_path)
             local clip_end = audio_block:match('clipEnd%s*=%s*"([^"]+)"')
 
             if audio_src then
+                audio_src = self:_urlDecode(audio_src) or audio_src
+                if text_src then
+                    text_src = self:_urlDecode(text_src) or text_src
+                end
                 -- Resolve relative paths
                 local resolved_audio = audio_src
                 if audio_src:sub(1, 1) ~= "/" and audio_base ~= "" then
@@ -462,6 +500,7 @@ function EpubMediaOverlay:_extractAudioFile(epub_path, internal_path, cache_dir)
     -- handful of distinct audio files), and the old check against only the
     -- flattened name made every single entry re-extract its multi-MB audio
     -- file from the zip.
+    internal_path = self:_urlDecode(internal_path) or internal_path
     if not self:_validateZipMember(internal_path) then
         logger.warn("EpubMediaOverlay: refusing unsafe audio path",
             tostring(internal_path))

--- a/epubmediaoverlay.lua
+++ b/epubmediaoverlay.lua
@@ -59,7 +59,9 @@ end
 -- literal spaces.  unzip then misses every SMIL and we report "no
 -- built-in audiobook" even though Readest still plays the same file.
 function EpubMediaOverlay:_urlDecode(path)
-    if not path or not path:find("%%", 1, true) then
+    -- plain find: "%" is one percent. "%%" would look for two percents
+    -- and skip every real %20 / %2C href (Readest/Calibre).
+    if not path or not path:find("%", 1, true) then
         return path
     end
     return (path:gsub("%%(%x%x)", function(hex)


### PR DESCRIPTION
## Summary
This is a **plugin** bug, not a KOReader document bug and not a broken export.

An EPUB is a zip. The OPF `href` is a URI; the zip member is a literal filename. Readest/Calibre rewrites the manifest to the spec (`MediaOverlays/005%20-%20PROLOGUE.smil`). The zip still stores `MediaOverlays/005 - PROLOGUE.smil`. That pairing is valid.

CREngine already percent-decodes `href`s, so the book **opens and paginates**. The overlay parser does not go through CREngine: it shells `unzip -p` with the raw OPF `href`. Info-ZIP then looks for a member whose name is the encoded string, finds nothing, and `loadFromEpub` returns “no timing data”. Overlay *detection* still succeeds (`unzip -l` sees `.smil`), which is why the UI says there is no built-in audiobook while Readest plays the same file.

KOReader’s file manager never unpacks the EPUB into OPF/HTML/SMIL next to the book. Those files stay inside the zip. The plugin only extracts the audio parts it needs under `audiobook.koplugin/cache/overlays/`, which is not a library folder.

Fix: decode `%HH` on OPF hrefs, SMIL `src`, and audio paths, then retry `unzip` with the decoded member name. Unencoded Storyteller exports keep working.

Lua note (second commit): a plain `find("%%")` looks for two percent signs, so `%20` never triggered the decoder. The guard must search for a single `"%"`. Both commits are required.

Verified on Boox (F-Droid KOReader) after a Readest re-save: Play aligned finds the 23 SMIL parts and plays. Same book with literal-space hrefs still parses.

## Test plan
- [x] Boox: Storyteller EPUB rewritten by Readest — **Play aligned audiobook** finds the SMIL parts and plays.
- [x] Same book before rewrite (literal-space hrefs) still parses.
- [ ] `luajit dev/test_epubmediaoverlay_multiline.lua` if fixtures are present.