### PR TITLE
kindle: refresh only the mini-bar clock, and resume SMIL audio from the pause mark

### DIFF
--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -144,6 +144,21 @@ local function _jpegDimensions(path)
     return nil, nil
 end
 
+function AudiobookPlayer:_isEink()
+    return Device.hasEinkScreen and Device:hasEinkScreen()
+end
+
+--- Sit above KOReader's footer when the user asked to keep it, or when the
+--- footer is a real page chrome (Overlap status bar off). Otherwise the mini
+--- player paints on top of the progress bar and e-ink ghosts a second bar.
+function AudiobookPlayer:_shouldSitAboveFooter()
+    if self.keep_reader_status_bars then return true end
+    local ui = self.ui_widget or (self.plugin and self.plugin.ui)
+    local view = ui and ui.view
+    if not (view and view.footer_visible and view.footer) then return false end
+    return not view.footer.reclaim_height
+end
+
 function AudiobookPlayer:init()
     self.width = Screen:getWidth()
     self.height = Screen:getHeight()
@@ -152,7 +167,7 @@ function AudiobookPlayer:init()
     -- Do not claim the whole screen / footer while the mini player is up —
     -- otherwise ReaderFooter may skip updates ("lost" status bar).
     self.covers_fullscreen = false
-    self.covers_footer = not self.keep_reader_status_bars
+    self.covers_footer = not self:_shouldSitAboveFooter()
     self._return_hint_active = false
     self._rotation_mode = Screen:getRotationMode()
     self:setupUI()
@@ -768,8 +783,8 @@ end
 --- MediaSync also reflows page margins by this chrome height + mini bar so
 --- book text never renders underneath the player.
 function AudiobookPlayer:_statusBarInset()
-    if not self.keep_reader_status_bars then return 0 end
-    local ui = self.plugin and self.plugin.ui
+    if not self:_shouldSitAboveFooter() then return 0 end
+    local ui = self.ui_widget or (self.plugin and self.plugin.ui)
     local view = ui and ui.view
     if not view or not view.footer_visible or not view.footer then return 0 end
     local ok, h = pcall(function() return view.footer:getHeight() end)
@@ -790,7 +805,7 @@ end
 function AudiobookPlayer:_applyMinimizedGeometry()
     self._minimized = true
     self.covers_fullscreen = false
-    self.covers_footer = not self.keep_reader_status_bars
+    self.covers_footer = not self:_shouldSitAboveFooter()
     self.dimen.h = self._mini_height
     self.dimen.y = self:_miniBarY()
 end
@@ -905,18 +920,53 @@ function AudiobookPlayer:setPlaying(is_playing)
     if self._mini_play_pause then
         self._mini_play_pause:setText(txt, self._mini_play_pause.width)
     end
-    UIManager:setDirty(self, function()
+    self:_dirtyChrome(self._minimized
+        and (self._mini_play_pause and self._mini_play_pause.dimen)
+        or (self.play_pause_button and self.play_pause_button.dimen))
+end
+
+--- Refresh a rectangle. Never fall back to the whole mini bar for a clock
+--- tick — that is what made the entire chrome jump on Kindle e-ink.
+function AudiobookPlayer:_dirtyChrome(region)
+    local mode = self:_isEink() and "fast" or "ui"
+    if not (region and region.w and region.h and region.w > 0 and region.h > 0) then
         if self._minimized then
-            return "ui", self.dimen
+            region = self:_miniTimeDirtyRegion()
+        else
+            UIManager:setDirty(self, mode)
+            return
         end
-        if self.play_pause_button and self.play_pause_button.dimen then
-            return "ui", self.play_pause_button.dimen
-        end
-        return "ui"
+    end
+    UIManager:setDirty(self, function()
+        return mode, region
     end)
 end
 
-function AudiobookPlayer:updateTimeDisplay(current_sec, total_sec)
+--- Tight screen rect around the elapsed/total label (the only 1 Hz change).
+function AudiobookPlayer:_miniTimeDirtyRegion()
+    local t = self._mini_time
+    if t and t.dimen and t.dimen.w and t.dimen.w > 0 then
+        local d = t.dimen
+        local pad = 2
+        return Geom:new{
+            x = math.max(0, d.x - pad),
+            y = math.max(0, d.y - pad),
+            w = d.w + pad * 2,
+            h = d.h + pad * 2,
+        }
+    end
+    local y = self:_miniBarY()
+    local h = math.max(12, math.floor(self._mini_height * 0.42))
+    local w = math.min(Screen:scaleBySize(180), self.width)
+    return Geom:new{
+        x = math.floor((self.width - w) / 2),
+        y = y + self._mini_height - h - 2,
+        w = w,
+        h = h,
+    }
+end
+
+function AudiobookPlayer:updateTimeDisplay(current_sec, total_sec, force)
     local text
     if self._time_display_mode == "chapter" and self._current_chapter_end > self._current_chapter_start then
         local chapter_pos = math.max(0, current_sec - self._current_chapter_start)
@@ -925,32 +975,29 @@ function AudiobookPlayer:updateTimeDisplay(current_sec, total_sec)
     else
         text = self:_formatTime(current_sec) .. " / " .. self:_formatTime(total_sec)
     end
-    if text ~= self.current_time_str then
-        self.current_time_str = text
-        self.time_widget:setText(text)
+    if text == self.current_time_str and not force then return end
+    self.current_time_str = text
+    self.time_widget:setText(text)
+    if self._mini_time then
         self._mini_time:setText(text)
-        UIManager:setDirty(self, function()
-            return "ui", self.time_widget.dimen
-        end)
+    end
+    if self._minimized then
+        self:_dirtyChrome(self:_miniTimeDirtyRegion())
+    else
+        self:_dirtyChrome(self.time_widget and self.time_widget.dimen)
     end
 end
 
-function AudiobookPlayer:updateProgress(progress)
+function AudiobookPlayer:updateProgress(progress, force)
     -- Suppress poller updates while user is dragging the scrubber
     if self._scrubber_dragging then return end
-    if progress ~= self.progress then
-        self.progress = progress
-        self.progress_bar:setPercentage(progress / 100)
-        if self._minimized then
-            UIManager:setDirty(self, function()
-                return "ui", self._mini_bar:getSize()
-            end)
-        else
-            UIManager:setDirty(self, function()
-                return "ui", self.progress_bar.dimen
-            end)
-        end
-    end
+    if progress == self.progress and not force then return end
+    self.progress = progress
+    self.progress_bar:setPercentage(progress / 100)
+    -- Mini chrome has no scrubber; time text is the 1 Hz progress. Dirtying
+    -- the whole bar here is what made Kindle jump.
+    if self._minimized then return end
+    self:_dirtyChrome(self.progress_bar and self.progress_bar.dimen)
 end
 
 function AudiobookPlayer:updateChapterTitle(title)
@@ -962,13 +1009,10 @@ function AudiobookPlayer:updateChapterTitle(title)
         -- Mini bar prefers chapter_title for read-aloud (see _updateMiniWidgets).
         if self._mini_title then
             self:_updateMiniWidgets()
+            self:_dirtyChrome(self._mini_title.dimen or self:_miniTimeDirtyRegion())
+        else
+            self:_dirtyChrome(self.chapter_widget and self.chapter_widget.dimen)
         end
-        UIManager:setDirty(self, function()
-            if self._minimized then
-                return "ui", self.dimen
-            end
-            return "ui", self.chapter_widget and self.chapter_widget.dimen or self.dimen
-        end)
     end
 end
 

--- a/btmediacontrol.lua
+++ b/btmediacontrol.lua
@@ -582,11 +582,91 @@ function BtMediaControl._startKindleAvrcpSupport()
     if BtMediaControl._kindle_avrcp_active then return end
     BtMediaControl._kindle_avrcp_active = true
     BtMediaControl._kindleAdvertisePlaybackState("paused")
+    BtMediaControl._startKindleLipcEventWatch()
     BtMediaControl._pollKindleAvrcp()
 end
 
 function BtMediaControl._stopKindleAvrcpSupport()
     BtMediaControl._kindle_avrcp_active = false
+    BtMediaControl._stopKindleLipcEventWatch()
+end
+
+-- PW11 / Lab126 Bluedroid never creates an AVRCP evdev node. Headset stem
+-- clicks still land on playermgr / audiomgrd / btfd as LIPC events (Pause,
+-- Play, Stop). Watch those in the background and treat them as toggles.
+local KINDLE_AVRCP_LOG = "/tmp/abk-kindle-avrcp.log"
+local KINDLE_LIPC_WATCH = {
+    "com.lab126.playermgr",
+    "com.lab126.audiomgrd",
+    "com.lab126.btfd",
+    "com.lab126.acsbt",
+}
+
+function BtMediaControl._startKindleLipcEventWatch()
+    if BtMediaControl._kindle_lipc_watch_started then return end
+    BtMediaControl._kindle_lipc_watch_started = true
+    os.execute("rm -f " .. KINDLE_AVRCP_LOG)
+    os.execute("touch " .. KINDLE_AVRCP_LOG)
+    for _, svc in ipairs(KINDLE_LIPC_WATCH) do
+        os.execute(string.format(
+            "( lipc-wait-event -m %s '*' >> %s 2>/dev/null ) &",
+            svc, KINDLE_AVRCP_LOG))
+    end
+    BtMediaControl._kindle_avrcp_log_pos = 0
+    logger.warn("BtMediaControl: Kindle LIPC AVRCP watch started")
+end
+
+function BtMediaControl._stopKindleLipcEventWatch()
+    if not BtMediaControl._kindle_lipc_watch_started then return end
+    BtMediaControl._kindle_lipc_watch_started = false
+    os.execute("pkill -f 'abk-kindle-avrcp' 2>/dev/null")
+    -- The redirect filename is the only unique token we own.
+    os.execute("pkill -f '/tmp/abk-kindle-avrcp.log' 2>/dev/null")
+end
+
+function BtMediaControl._consumeKindleLipcEvents()
+    local f = io.open(KINDLE_AVRCP_LOG, "r")
+    if not f then return end
+    f:seek("set", BtMediaControl._kindle_avrcp_log_pos or 0)
+    local chunk = f:read("*a") or ""
+    BtMediaControl._kindle_avrcp_log_pos = f:seek()
+    f:close()
+    if chunk == "" then return end
+    local now = os.time()
+    for line in chunk:gmatch("[^\n]+") do
+        -- Ignore our own status chatter and volume / connection noise.
+        if line:find("audioOutput", 1, true)
+            or line:find("speakerVolume", 1, true)
+            or line:find("ListConnected", 1, true) then
+            -- skip
+        else
+            local ev = line:lower()
+            local is_pause = ev:find("%f[%a]pause%f[%A]")
+            local is_play = ev:find("%f[%a]play%f[%A]")
+                or ev:find("%f[%a]playparameter%f[%A]")
+            local is_stop = ev:find("%f[%a]stop%f[%A]")
+            local is_next = ev:find("%f[%a]next%f[%A]") or ev:find("forward", 1, true)
+            local is_prev = ev:find("%f[%a]prev%f[%A]") or ev:find("backward", 1, true)
+            if is_pause or is_play or is_stop or is_next or is_prev then
+                if BtMediaControl._kindle_avrcp_debounce
+                    and (now - BtMediaControl._kindle_avrcp_debounce) < 1 then
+                    logger.warn("BtMediaControl: Kindle LIPC debounce", line)
+                else
+                    BtMediaControl._kindle_avrcp_debounce = now
+                    logger.warn("BtMediaControl: Kindle LIPC AVRCP", line)
+                    if is_next then
+                        BtMediaControl._dispatchMediaEvent("MediaNext")
+                    elseif is_prev then
+                        BtMediaControl._dispatchMediaEvent("MediaPrev")
+                    else
+                        -- Stem clicks on Soundcore / AirPods are one button:
+                        -- treat Play, Pause, and Stop as a toggle.
+                        BtMediaControl._dispatchMediaEvent("MediaPlayPause")
+                    end
+                end
+            end
+        end
+    end
 end
 
 function BtMediaControl._btuiAvailable()
@@ -620,11 +700,15 @@ function BtMediaControl._pollKindleAvrcp()
     if not BtMediaControl._kindle_avrcp_active then return end
 
     -- Late-appearing media input nodes after AirPods reconnect.
-    if not BtMediaControl._evdev_active then
+    local scans = (BtMediaControl._kindle_evdev_scans or 0) + 1
+    BtMediaControl._kindle_evdev_scans = scans
+    if not BtMediaControl._evdev_active and scans % 4 == 0 then
         if BtMediaControl._tryEvdevApproach() then
             logger.warn("BtMediaControl: Kindle media input appeared on rescan")
         end
     end
+
+    BtMediaControl._consumeKindleLipcEvents()
 
     -- Some firmwares toggle playermgr InPlayback when the headset sends AVRCP.
     local h = io.popen("lipc-get-prop com.lab126.playermgr InPlayback 2>/dev/null")
@@ -648,7 +732,8 @@ function BtMediaControl._pollKindleAvrcp()
     end
 
     if BtMediaControl._kindle_avrcp_active then
-        UIManager:scheduleIn(1.5, BtMediaControl._pollKindleAvrcp)
+        -- LIPC log is written by background waiters; 0.4s keeps stem clicks snappy.
+        UIManager:scheduleIn(0.4, BtMediaControl._pollKindleAvrcp)
     end
 end
 

--- a/highlightmanager.lua
+++ b/highlightmanager.lua
@@ -103,10 +103,35 @@ function HighlightManager:_refreshHighlight(new_boxes, page)
     if new_boxes and #new_boxes > 0 then
         table.insert(arrays, new_boxes)
     end
-    UIManager:setDirty(self.ui.dialog or "all", "ui",
-        boxesUnionRegion(arrays))
+    local region = boxesUnionRegion(arrays)
+    if region then
+        -- Keep the e-ink refresh off the mini player / KOReader footer so
+        -- sentence updates do not flash a second ghost bar at the bottom.
+        local bar_top = self:_overlayBarTop()
+        if bar_top and region.y + region.h > bar_top then
+            region.h = math.max(0, bar_top - region.y)
+        end
+        if region.h > 0 then
+            UIManager:setDirty(self.ui.dialog or "all", "ui", region)
+        end
+    end
     self._last_boxes = new_boxes
     self._last_boxes_page = page
+end
+
+function HighlightManager:_overlayBarTop()
+    local p = self.plugin
+    local bar = p and p.media_sync and p.media_sync.playback_bar
+    if bar and bar._minimized then
+        if bar.dimen and bar.dimen.y and bar.dimen.y > 0 then
+            return bar.dimen.y
+        end
+        if bar._miniBarY then
+            local ok, y = pcall(function() return bar:_miniBarY() end)
+            if ok and type(y) == "number" and y > 0 then return y end
+        end
+    end
+    return nil
 end
 
 function HighlightManager:setStyle(style)

--- a/main.lua
+++ b/main.lua
@@ -600,7 +600,7 @@ function Audiobook:addToMainMenu(menu_items)
                                 BtMediaControl.stop()
                             end
                         end,
-                        help_text = _("When enabled, play/pause/next/prev buttons on a Bluetooth headset or speaker will control playback. The connected device will also show playback status.\n\nNote: Kindle Paperwhite does not expose an AVRCP input device for AirPods stem presses (no btui / no media-key evdev). Stem play/pause is not available on this firmware; use the on-screen controls or Kindle buttons."),
+                        help_text = _("When enabled, play/pause/next/prev buttons on a Bluetooth headset or speaker will control playback. The connected device will also show playback status.\n\nOn Kindle, stem clicks are read from Lab126 LIPC (playermgr / audiomgrd) because this firmware has no AVRCP evdev node."),
                     },
                     {
                         text = _("Reconnect BT on track change"),

--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -2685,6 +2685,12 @@ end
 
 function MediaEngine:pause()
     if not self.is_playing or self.is_paused then return end
+    -- Snapshot while the pipeline is still live. Setting is_paused first
+    -- made Kindle getPosition() miss or reuse a stale mark, so resume jumped.
+    local live_pos = 0
+    pcall(function() live_pos = self:getPosition() or 0 end)
+    if not live_pos or live_pos < 0 then live_pos = 0 end
+
     self.is_paused = true
     self._pause_start_time = UIManager:getTime()
 
@@ -2743,9 +2749,7 @@ function MediaEngine:pause()
     -- audiomgrd within seconds; SIGCONT then produces a silent "playing"
     -- pipeline.  Halt content, park a silence keepalive so A2DP stays up.
     if self:_kindleNeedsPipelineRestartOnResume() then
-        local pos = 0
-        pcall(function() pos = self:getPosition() or 0 end)
-        self._paused_position = math.max(0, pos)
+        self._paused_position = math.max(0, live_pos)
         self._seek_offset = self._paused_position
         logger.warn("MediaEngine: Kindle A2DP pause-halt at", self._paused_position,
             "apple=", self:_isAppleAirPodsHeadset() and "yes" or "no")

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -944,13 +944,14 @@ function MediaSync:_refreshPlaybackTimeUi()
         end
     end
     pcall(function()
-        self.playback_bar:updateTimeDisplay(bar_pos or 0, bar_dur or 0)
+        -- force=true so e-ink paints immediately on pin / seek / pause.
+        self.playback_bar:updateTimeDisplay(bar_pos or 0, bar_dur or 0, true)
         if bar_dur and bar_dur > 0 then
             local pct = math.floor(((bar_pos or 0) / bar_dur) * 100)
             if pct < 0 then pct = 0 end
             if pct > 100 then pct = 100 end
             self._last_progress_pct = pct
-            self.playback_bar:updateProgress(pct)
+            self.playback_bar:updateProgress(pct, true)
         end
     end)
     self:_refreshPlaybackBarTitles()
@@ -1220,6 +1221,7 @@ function MediaSync:pause(auto)
     if self.playback_bar then
         pcall(function() self.playback_bar:setPlaying(false) end)
     end
+    pcall(function() self:_refreshPlaybackTimeUi() end)
     logger.warn("MediaSync: paused", auto and "(auto)" or "", "at", pos)
 end
 
@@ -1263,6 +1265,7 @@ function MediaSync:resume(auto)
             self.playback_bar:setPlaying(true)
         end)
     end
+    pcall(function() self:_refreshPlaybackTimeUi() end)
     -- The sync loop self-terminates while paused: its tick bails out without
     -- rescheduling once state != PLAYING.  Restart it (and the position
     -- poller, for symmetry) so the highlight tracks the audio again instead of
@@ -1516,12 +1519,7 @@ function MediaSync:_refreshPlaybackBarTitles()
     end
     if not label or label == "" then return end
     pcall(function()
-        -- Force mini refresh even when the chapter label is unchanged (e.g. first
-        -- paint used the book title before chapter_title was applied).
         local bar = self.playback_bar
-        if bar.chapter_title == label and bar._mini_title then
-            bar:_updateMiniWidgets()
-        end
         bar:updateChapterTitle(label)
         if ch and bar.setCurrentChapter then
             bar:setCurrentChapter(ch)
@@ -1904,8 +1902,11 @@ function MediaSync:_updateHighlightAtTime(pos)
                     self.highlight_manager:highlightWord(word, {sentences = {sentence}})
                 end)
             end
-            -- Update playback bar word display (only in non-scrubber mode)
-            if self.playback_bar and not self.playback_bar.scrubber_mode then
+            -- TTS PlaybackBar can show the spoken word. Overlay AudiobookPlayer
+            -- uses that slot for the chapter title — rewriting it every word
+            -- flashes the Kindle footer into a second ghost bar.
+            if self.playback_bar and not self.overlay_mode
+                and not self.playback_bar.scrubber_mode then
                 pcall(function()
                     self.playback_bar:updateCurrentWord(word.text or "")
                 end)
@@ -2301,12 +2302,12 @@ function MediaSync:_startPositionPoller(gen)
             pcall(function()
                 self.playback_bar:updateTimeDisplay(display_pos, display_dur)
             end)
-            -- Update chapter title (overlay: SMIL chapter across audio parts)
+            -- Only rewrite the chapter label when it actually changes. A 1 Hz
+            -- force-refresh ghosts a second bar on Kindle e-ink.
             local ok_ch, ch, ch_idx = pcall(function() return self:getCurrentChapter() end)
-            if ok_ch then
+            if ok_ch and ch_idx ~= self._last_bar_chapter_idx then
+                self._last_bar_chapter_idx = ch_idx
                 pcall(function() self:_refreshPlaybackBarTitles() end)
-                -- Update chapter menu highlight if it's open (chapter mode only;
-                -- playlist mode uses playlist index, not chapter index)
                 if self._chapter_menu and ch_idx and not self.playlist_files then
                     local menu = self._chapter_menu
                     if menu.item_table.current ~= ch_idx then
@@ -2588,10 +2589,9 @@ function MediaSync:showPlaybackBar()
         -- BT reconnect lives in plugin settings (Reconnect BT on track change)
         -- and the Bluetooth menu — no overlay "BT" button.
         show_fix_audio = false,
-        keep_reader_status_bars = self.plugin
-            and self.plugin.getSetting
-            and self.plugin:getSetting("keep_reader_status_bars", false)
-            or false,
+        -- Sit above a visible KOReader footer even when the user did not
+        -- toggle "Keep status bars" — otherwise the mini player overlaps it.
+        keep_reader_status_bars = self:_miniBarAboveFooter(),
     }
     player:show()
     if self.plugin then


### PR DESCRIPTION
## Summary
Kindle Paperwhite 11 e-ink was flashing the **entire** overlay mini bar (and ghosting a second bar over KOReader’s footer) because the 1 Hz clock tick dirtied the whole chrome. The clock should still update every second; only that label’s rectangle should refresh.

Pause on `kindle-gst-play` halted the pipeline **before** saving position, so Play could restart from the wrong mark. Snapshot the live position first, then halt, then resume-restart at that offset.

This firmware has no AVRCP evdev node (touch + power key only). Headset stem clicks are watched on Lab126 LIPC (`playermgr` / `audiomgrd` / `btfd`) instead.

Tested on Kindle Paperwhite 11 (KOReader v2026.07.2) with a Storyteller EPUB and Soundcore Liberty. Boox Android pause/resume is unchanged (MediaPlayer path).

## Test plan
- [x] Kindle: SMIL read-along — elapsed time ticks every second without the whole mini bar jumping.
- [x] Kindle: Pause stops at the current sentence/time; Play continues from there.
- [x] Kindle: Mini bar sits above the KOReader footer (no overlapping ghost bar).
- [ ] Kindle: Soundcore/AirPods stem play-pause (LIPC). If it still does nothing, generate a bug report after a stem click.
- [ ] Boox: overlay pause/play still resumes from the pause mark (no regression).

Made with [Cursor](https://cursor.com)