### PR TITLE
fix(selection): avoid duplicate actions after Wikipedia lookup

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -236,7 +236,8 @@ function Audiobook:_registerDictButtons()
         font_bold = false,
         conditional = true,
         show_func = function(dict_popup)
-            return plugin._init_ok and not dict_popup.is_wiki_fullpage
+            return plugin._init_ok and not dict_popup.is_wiki
+                and not dict_popup.is_wiki_fullpage
         end,
         callback = function(dict_popup)
             local word = dict_popup.word or dict_popup.lookupword
@@ -271,7 +272,8 @@ function Audiobook:_registerDictButtons()
         font_bold = false,
         conditional = true,
         show_func = function(dict_popup)
-            return plugin._init_ok and not dict_popup.is_wiki_fullpage
+            return plugin._init_ok and not dict_popup.is_wiki
+                and not dict_popup.is_wiki_fullpage
         end,
         callback = function(dict_popup)
             local selected_text = nil


### PR DESCRIPTION
## Summary

Prevent the audiobook actions registered in KOReader's dictionary popup from
being added to Wikipedia dialogs.

Regular Wikipedia dialogs use `is_wiki`, while the current registration path
only excludes `is_wiki_fullpage`. Because the dictionary button layout can be
reused afterward, this can leave duplicate **Read aloud from here** and
**Play aligned audiobook from here** actions in a subsequent dictionary lookup.

This change excludes both Wikipedia dialog variants.

## Steps to reproduce

1. Long-press a word and open a normal dictionary lookup.
2. Open Wikipedia from that lookup.
3. Close Wikipedia.
4. Long-press a **different word** and open another dictionary lookup.
5. **Read aloud from here** and **Play aligned audiobook from here** appear duplicated.

### Before

![Duplicate audiobook actions after Wikipedia lookup](https://github.com/user-attachments/assets/87b0f5a6-0a57-4865-a5e7-37bb24e2cd2e)

## Test plan

- [x] Reproduced the duplicate actions before applying the patch.
- [x] Open a normal dictionary lookup and confirm both audiobook actions appear once.
- [x] Open Wikipedia, close it, then look up a different word.
- [x] Confirm the audiobook actions are no longer duplicated.
- [x] Confirm both actions still work from a normal dictionary lookup.