### PR TITLE
feat(player): replace speed cycling with a speed picker

### DIFF
--- a/audiobookplayer.lua
+++ b/audiobookplayer.lua
@@ -944,7 +944,126 @@ function AudiobookPlayer:onSeek(pct)
 end
 
 function AudiobookPlayer:onSpeed()
-    if self.on_speed then self.on_speed() end
+    local ButtonDialog = require("ui/widget/buttondialog")
+    local min_speed = self.tts_mode and 0.25 or 0.5
+    local max_speed = self.tts_mode and 2.0 or 3.0
+    local presets = { 0.8, 1.0, 1.25, 1.5, 2.0 }
+    local player = self
+    local current = self.playback_speed or 1.0
+
+    local function closeDialog()
+        if player._speed_dialog then
+            UIManager:close(player._speed_dialog)
+            player._speed_dialog = nil
+        end
+    end
+
+    local function refreshDialog()
+        local dialog = player._speed_dialog
+        if not dialog then return end
+        local value = dialog:getButtonById("speed_value")
+        if value then value:setText(player:_speedText(), value.width) end
+        local slower_10 = dialog:getButtonById("speed_slower_10")
+        if slower_10 then
+            slower_10:enableDisable(current >= min_speed + 0.1 - 0.001)
+        end
+        local slower_05 = dialog:getButtonById("speed_slower_05")
+        if slower_05 then
+            slower_05:enableDisable(current >= min_speed + 0.05 - 0.001)
+        end
+        local faster_05 = dialog:getButtonById("speed_faster_05")
+        if faster_05 then
+            faster_05:enableDisable(current <= max_speed - 0.05 + 0.001)
+        end
+        local faster_10 = dialog:getButtonById("speed_faster_10")
+        if faster_10 then
+            faster_10:enableDisable(current <= max_speed - 0.1 + 0.001)
+        end
+        for _, preset in ipairs(presets) do
+            local button = dialog:getButtonById("speed_preset_" .. tostring(preset))
+            if button then
+                local text = (math.abs(current - preset) < 0.01 and "✓ " or "")
+                    .. string.format("%g×", preset)
+                button:setText(text, button.width)
+            end
+        end
+        UIManager:setDirty(dialog, "ui")
+    end
+
+    local function applySpeed(speed, keep_open)
+        speed = math.max(min_speed, math.min(max_speed,
+            tonumber(speed) or 1.0))
+        speed = math.floor(speed * 100 + 0.5) / 100
+        if not keep_open then closeDialog() end
+        current = speed
+        if player.on_speed then player.on_speed(speed) end
+        if keep_open then refreshDialog() end
+    end
+
+    local function adjustSpeed(delta)
+        applySpeed(current + delta, true)
+    end
+
+    local preset_buttons = {}
+    for _, speed in ipairs(presets) do
+        local preset_speed = speed
+        table.insert(preset_buttons, {
+            id = "speed_preset_" .. tostring(preset_speed),
+            text = (math.abs(current - preset_speed) < 0.01 and "✓ " or "")
+                .. string.format("%g×", preset_speed),
+            callback = function() applySpeed(preset_speed, false) end,
+        })
+    end
+
+    self._speed_dialog = ButtonDialog:new{
+        title = _("Playback speed"),
+        _plugin_chrome = true,
+        buttons = {
+            {
+                {
+                    id = "speed_slower_10",
+                    text = "− 0.1",
+                    enabled = current >= min_speed + 0.1 - 0.001,
+                    callback = function()
+                        adjustSpeed(-0.1)
+                    end,
+                },
+                {
+                    id = "speed_slower_05",
+                    text = "− 0.05",
+                    enabled = current >= min_speed + 0.05 - 0.001,
+                    callback = function()
+                        adjustSpeed(-0.05)
+                    end,
+                },
+                { id = "speed_value", text = self:_speedText(), enabled = false },
+                {
+                    id = "speed_faster_05",
+                    text = "+ 0.05",
+                    enabled = current <= max_speed - 0.05 + 0.001,
+                    callback = function()
+                        adjustSpeed(0.05)
+                    end,
+                },
+                {
+                    id = "speed_faster_10",
+                    text = "+ 0.1",
+                    enabled = current <= max_speed - 0.1 + 0.001,
+                    callback = function()
+                        adjustSpeed(0.1)
+                    end,
+                },
+            },
+            preset_buttons,
+            {
+                {
+                    text = _("Close"),
+                    callback = closeDialog,
+                },
+            },
+        },
+    }
+    UIManager:show(self._speed_dialog)
 end
 
 function AudiobookPlayer:onTtsSettings()

--- a/mediasync.lua
+++ b/mediasync.lua
@@ -2547,18 +2547,8 @@ function MediaSync:showPlaybackBar()
         on_chapter_list = function()
             self:showChapterList()
         end,
-        on_speed = function()
-            -- Cycle speeds: 0.8 → 1.0 → 1.25 → 1.5 → 2.0 → 0.8
-            local speeds = {0.8, 1.0, 1.25, 1.5, 2.0}
-            local current = self.media_engine and self.media_engine:getSpeed() or 1.0
-            local next_speed = speeds[1]
-            for i, s in ipairs(speeds) do
-                if math.abs(current - s) < 0.01 then
-                    next_speed = speeds[i + 1] or speeds[1]
-                    break
-                end
-            end
-            self:setSpeed(next_speed)
+        on_speed = function(speed)
+            self:setSpeed(speed)
         end,
         on_shuffle = function()
             self:shufflePlaylist()

--- a/synccontroller.lua
+++ b/synccontroller.lua
@@ -1459,8 +1459,8 @@ function SyncController:showPlaybackBar()
         on_chapter_list = function()
             controller:showTocPicker()
         end,
-        on_speed = function()
-            controller:cycleSpeechRate()
+        on_speed = function(speed)
+            controller:setSpeechRate(speed)
         end,
         on_volume = function(pct)
             controller:setSpeechVolumePct(pct)
@@ -2587,6 +2587,24 @@ function SyncController:_refreshTtsTimeUi()
     pcall(function() bar:updateTimeDisplay(elapsed, total) end)
 end
 
+-- Apply an explicit TTS rate selected by the shared audiobook-player speed UI.
+-- TTSEngine supports 0.25x..2.0x, which is intentionally narrower than the
+-- aligned-audio player's 0.5x..3.0x range.
+function SyncController:setSpeechRate(speed)
+    speed = tonumber(speed) or 1.0
+    speed = math.max(0.25, math.min(2.0, speed))
+    if self.plugin and self.plugin.setSetting then
+        self.plugin:setSetting("speech_rate", speed)
+    end
+    if self.tts_engine and self.tts_engine.setRate then
+        self.tts_engine:setRate(speed)
+    end
+    if self.playback_bar and self.playback_bar.updateSpeed then
+        pcall(function() self.playback_bar:updateSpeed(speed) end)
+    end
+    return speed
+end
+
 -- Same rate list as the speech-rate picker in the TTS settings dialog.
 function SyncController:cycleSpeechRate()
     local speeds = {0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0}
@@ -2599,15 +2617,7 @@ function SyncController:cycleSpeechRate()
             break
         end
     end
-    if plugin and plugin.setSetting then
-        plugin:setSetting("speech_rate", next_speed)
-    end
-    if self.tts_engine and self.tts_engine.setRate then
-        self.tts_engine:setRate(next_speed)
-    end
-    if self.playback_bar and self.playback_bar.updateSpeed then
-        pcall(function() self.playback_bar:updateSpeed(next_speed) end)
-    end
+    self:setSpeechRate(next_speed)
 end
 
 function SyncController:setSpeechVolumePct(pct)


### PR DESCRIPTION
## Summary

Replace the playback-speed button's tap-to-cycle behavior with a compact speed
picker shared by aligned-audio playback and TTS.

The picker provides:

- presets for 0.8×, 1×, 1.25×, 1.5×, and 2×;
- ±0.05× and ±0.1× fine adjustments;
- the current speed and a checkmark on the selected preset;
- the existing 0.5×–3× range for aligned audio;
- the existing 0.25×–2× range for TTS.

Selecting a preset applies it and closes the dialog. Fine adjustments apply
immediately while keeping the dialog open, making it possible to tune the
speed while listening without repeatedly reopening the picker.

### Preview

![Playback speed picker](https://github.com/user-attachments/assets/0adb94bb-ae20-4f96-9cc9-7e75627bf8c2)

## UX note

I think opening the picker on a normal tap is the more useful default.

The current tap-to-cycle behavior requires stepping through several rates to
reach a particular value, while a picker makes the available presets visible
and also provides access to fine adjustments.

If preserving the existing quick-cycle behavior is preferred, another option
would be to keep tap-to-cycle and open the picker on long press.

## Test plan

- [x] Test preset selection with aligned EPUB 3 audio.
- [x] Test ±0.05× and ±0.1× adjustments with aligned audio.
- [x] Confirm the aligned-audio range is limited to 0.5×–3×.
- [x] Test preset selection with TTS.
- [x] Test ±0.05× and ±0.1× adjustments with TTS.
- [x] Confirm selecting 1× in TTS applies 1× directly.
- [x] Confirm the TTS range is limited to 0.25×–2×.
- [x] Confirm TTS continues playing while the speed picker is open.
- [x] Confirm the displayed current rate updates while making fine adjustments.
- [x] Confirm the selected preset is marked correctly.