### PR TITLE
kindle: fall back to GStreamer 1.0 when gst-launch-0.10 is missing

### DIFF
--- a/mediaengine.lua
+++ b/mediaengine.lua
@@ -1820,13 +1820,23 @@ function MediaEngine:_playSystemGstLaunch(gen)
     self:_killOrphanKindleGstPipelines("kindle-gst-wav", 150000,
         self._keepalive_pid and { content_only = true } or nil)
 
-    local caps = string.format(
-        "audio/x-raw-int,endianness=1234,signed=true,width=%d,depth=%d,rate=%d,channels=%d",
-        bits, bits, rate, channels)
+    local caps, gst_cmd
+    if MediaEngine:commandExists("gst-launch-0.10") then
+        gst_cmd = "gst-launch-0.10"
+        caps = string.format(
+            "audio/x-raw-int,endianness=1234,signed=true,width=%d,depth=%d,rate=%d,channels=%d",
+            bits, bits, rate, channels)
+    else
+        -- Newer firmware ships GStreamer 1.0 only; use 1.0 raw caps + binary.
+        gst_cmd = "gst-launch-1.0"
+        caps = string.format(
+            "audio/x-raw,format=%s,rate=%d,channels=%d,layout=interleaved",
+            bits == 16 and "S16LE" or "U8", rate, channels)
+    end
     local cmd = string.format(
-        "gst-launch-0.10 filesrc location='%s' ! capsfilter caps='%s'"
+        "%s filesrc location='%s' ! capsfilter caps='%s'"
         .. " ! mixersink stream-type=Music sync=true",
-        raw_file:gsub("'", "'\\''"), caps)
+        gst_cmd, raw_file:gsub("'", "'\\''"), caps)
     logger.warn("MediaEngine: system gst-launch gen=", gen,
         "rate=", rate, "ch=", channels, "seek_offset=", self._seek_offset or 0,
         "apple_airpods=", apple and "yes" or "no")
@@ -1856,7 +1866,20 @@ would otherwise be swallowed by the ring/BT chain at EOS.
 --]]
 function MediaEngine:_playSystemGstLaunchFfmpeg(gen)
     local ffmpeg = self:_findFfmpeg()
-    if not ffmpeg or not self:commandExists("gst-launch-0.10") then
+    if not ffmpeg then
+        return nil
+    end
+    local gst_cmd, raw_caps, fdsrc_args
+    if self:commandExists("gst-launch-0.10") then
+        gst_cmd = "gst-launch-0.10"
+        raw_caps = "audio/x-raw-int,rate=22050,channels=1,width=16,depth=16,signed=true,endianness=1234"
+        fdsrc_args = "fdsrc"
+    elseif self:commandExists("gst-launch-1.0") then
+        -- Newer firmware ships GStreamer 1.0 only; use 1.0 raw caps + binary.
+        gst_cmd = "gst-launch-1.0"
+        raw_caps = "audio/x-raw,format=S16LE,rate=22050,channels=1,layout=interleaved"
+        fdsrc_args = "fdsrc do-timestamp=true"
+    else
         return nil
     end
 
@@ -1908,11 +1931,12 @@ function MediaEngine:_playSystemGstLaunchFfmpeg(gen)
         "%s -loglevel error -progress '%s' -nostats -ss %.3f -i '%s'"
         .. " -f s16le -ar 22050 -ac 1"
         .. " -af adelay=%d:all=1%s,apad=pad_dur=%.1f - 2>/dev/null"
-        .. " | gst-launch-0.10 fdsrc"
-        .. " ! 'audio/x-raw-int,rate=22050,channels=1,width=16,depth=16,signed=true,endianness=1234'"
+        .. " | %s %s"
+        .. " ! '%s'"
         .. " ! mixersink stream-type=Music sync=true",
         ffmpeg:gsub("'", "'\\''"), progress_file:gsub("'", "'\\''"), seek,
-        self.current_path:gsub("'", "'\\''"), adelay_ms, self:_volumeFilterPart(), apad_s)
+        self.current_path:gsub("'", "'\\''"), adelay_ms, self:_volumeFilterPart(), apad_s,
+        gst_cmd, fdsrc_args, raw_caps)
     -- out_time is the PRODUCER side: it leads what the listener hears by the
     -- whole downstream buffer -- OS pipe (~1.5 s when full) + gst/mixersink
     -- ring (~0.9 s) + BT chain (~0.3 s) ~= 2.7 s.  AirPods buffer a bit more.
@@ -2284,7 +2308,7 @@ function MediaEngine:_playKindleGstPlay(gen)
     -- sets neither stream-type nor sync on mixersink and hangs on these
     -- firmwares.  Fall back to it only for non-PCM-WAV input or when
     -- gst-launch-0.10 is missing.
-    if self:commandExists("gst-launch-0.10") then
+    if self:commandExists("gst-launch-0.10") or self:commandExists("gst-launch-1.0") then
         local ok = self:_playSystemGstLaunch(gen)
         if ok then return ok end
     end


### PR DESCRIPTION
I validated this on my device after having the problem. Playback works perfectly after, please let me know if you want any changes.

## Problem

On Kindle firmware that ships **GStreamer 1.0 only** (no `gst-launch-0.10` binary, no `libgstreamer-0.10.so` — e.g. a 2024 Paperwhite on 5.19.x), playing any non-WAV media through the `kindle-gst-play` backend fails with:

```
ERROR MediaSync: playback failed: premature pipeline exit
WARN  MediaEngine: premature pipeline exit at 2.406 dur= 3138.59 — treating as fail (A2DP recovery)
```

The failure chain: `_playSystemGstLaunchFfmpeg` returns nil because `gst-launch-0.10` is missing → `_playKindleGstPlay` falls through to the bundled `gst-play` wrapper → the wrapper only handles raw PCM WAV and exits with `gst-play: not a WAV file`. This breaks playback of MP3/M4B/AAC audiobooks and Storyteller readaloud EPUBs (MP4/AAC chapter audio) on these devices.

## Fix

Add a `gst-launch-1.0` fallback when 0.10 is absent:

- **`_playSystemGstLaunch`** (WAV path): use `gst-launch-1.0` with 1.0 raw caps (`audio/x-raw,format=S16LE/U8,layout=interleaved`)
- **`_playSystemGstLaunchFfmpeg`** (mp3/m4b/aac path): same fallback, plus `fdsrc do-timestamp=true` — 1.0's fdsrc needs timestamps for the downstream `sync=true` sink; the old 0.10 fdsrc lacks that property, so the 0.10 path is byte-for-byte unchanged
- **`_playKindleGstPlay`**: attempt the system pipeline when *either* `gst-launch-0.10` or `gst-launch-1.0` exists

Amazon's `mixersink` element is present and functional under gst-1.0 (`gst-inspect-1.0 mixersink`), so no other changes are needed.

## Verification

On-device (Kindle, GStreamer 1.0.20.0, no 0.10 tools/libs):

- `bin/ffmpeg -i chapter.mp4 -f s16le -ar 22050 -ac 1 - | gst-launch-1.0 fdsrc do-timestamp=true ! 'audio/x-raw,format=S16LE,rate=22050,channels=1,layout=interleaved' ! mixersink stream-type=Music sync=true` → pipeline prerolls and plays cleanly, exit 0
- The bundled `gst-play` wrapper itself confirms the 1.0 path works (it dlopens `libgstreamer-1.0.so` and plays WAV via the same mixersink pipeline shape)
- Playing a Storyteller readaloud EPUB that previously died with "premature pipeline exit" now plays

0.10-only devices are unaffected: every changed path first checks for `gst-launch-0.10` and keeps the original pipeline/caps when it's present.
